### PR TITLE
Support reading from stdin

### DIFF
--- a/cmd/gold/main.go
+++ b/cmd/gold/main.go
@@ -10,6 +10,22 @@ import (
 	"github.com/charmbracelet/gold"
 )
 
+func readerFromArgument(s string) (io.ReadCloser, error) {
+	if s == "-" {
+		return os.Stdin, nil
+	}
+
+	if isGitHubURL(s) {
+		resp, err := findGitHubREADME(s)
+		if err != nil {
+			return nil, err
+		}
+		return resp.Body, nil
+	}
+
+	return os.Open(s)
+}
+
 func main() {
 	s := flag.String("s", "", "style json path")
 	flag.Parse()
@@ -19,26 +35,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	var in io.Reader
-	if isGitHubURL(args[0]) {
-		resp, err := findGitHubREADME(args[0])
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-
-		defer resp.Body.Close()
-		in = resp.Body
-	} else {
-		f, err := os.Open(args[0])
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-
-		defer f.Close()
-		in = f
+	in, err := readerFromArgument(args[0])
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
 	}
+	defer in.Close()
 
 	b, _ := ioutil.ReadAll(in)
 	out, err := gold.RenderBytes(b, *s)


### PR DESCRIPTION
When you start gold with "-" as an argument it will read directly
from stdin, instead of opening a file.

Example calls:

```
./gold -s dark.json README.md
```

or

```
cat README.md | ./gold -s dark.json
```