### PR TITLE
Fix new-line before first paragraph

### DIFF
--- a/gold.go
+++ b/gold.go
@@ -110,7 +110,7 @@ func NewElement(node *bf.Node) Element {
 		}
 	case bf.Paragraph:
 		pre := "\n"
-		if node.Parent != nil && node.Parent.Type == bf.Item {
+		if node.Prev == nil || (node.Parent != nil && node.Parent.Type == bf.Item) {
 			pre = ""
 		}
 


### PR DESCRIPTION
If the first item isn't a heading but a paragraph, don't prefix it with a newline.