### PR TITLE
Use ElementStyles to determine rendering style

### DIFF
--- a/cmd/gold/dark.json
+++ b/cmd/gold/dark.json
@@ -3,6 +3,13 @@
     "color": "123",
     "underline": true
   },
+  "link_text": {
+    "color": "123",
+    "bold": true
+  },
+  "image": {
+    "color": "8"
+  },
   "heading": {
     "bold": true,
     "color": "3"


### PR DESCRIPTION
Since BlackFriday's Nodes are limiting us a bit in rendering
flexibility, I've introduced Gold's own ElementStyles (a bit of
code repetition here, but alas).

Nodes can now be divided into multiple fragments, which means
we are able to display the link's URL and text in different styles.

Updated the dark theme to demo the newly gained flexibility.

Fixes #1.