### PR TITLE
Support github URLs without protocol

### DIFF
--- a/cmd/gold/github.go
+++ b/cmd/gold/github.go
@@ -8,13 +8,17 @@ import (
 )
 
 // isGitHubURL tests a string to determine if it is a well-structured GitHub URL
-func isGitHubURL(s string) bool {
-	u, err := url.ParseRequestURI(s)
-	if err != nil {
-		return false
+func isGitHubURL(s string) (string, bool) {
+	if strings.HasPrefix(s, "github.com/") {
+		s = "https://" + s
 	}
 
-	return strings.ToLower(u.Host) == "github.com"
+	u, err := url.ParseRequestURI(s)
+	if err != nil {
+		return "", false
+	}
+
+	return u.String(), strings.ToLower(u.Host) == "github.com"
 }
 
 // findGitHubREADME tries to find the correct README filename in a repository

--- a/cmd/gold/main.go
+++ b/cmd/gold/main.go
@@ -34,17 +34,17 @@ func readerFromArg(s string) (io.ReadCloser, error) {
 		return os.Stdin, nil
 	}
 
+	if u, ok := isGitHubURL(s); ok {
+		resp, err := findGitHubREADME(u)
+		if err != nil {
+			return nil, err
+		}
+		return resp.Body, nil
+	}
+
 	if u, err := url.ParseRequestURI(s); err == nil {
 		if !strings.HasPrefix(u.Scheme, "http") {
 			return nil, fmt.Errorf("%s is not a supported protocol", u.Scheme)
-		}
-
-		if isGitHubURL(s) {
-			resp, err := findGitHubREADME(s)
-			if err != nil {
-				return nil, err
-			}
-			return resp.Body, nil
 		}
 
 		resp, err := http.Get(u.String())


### PR DESCRIPTION
You can now call gold like:

```
./gold github.com/foo/bar
```