### PR TITLE
Link to cmd/gold instead of main.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ color and terminal codes instead of CSS properties and hex colors.
 
 ## Usage
 
-See [cmd/gold](cmd/gold/main.go).
+See [cmd/gold](cmd/gold/).
 
 ## Colors
 


### PR DESCRIPTION
The README is probably what the user wants to see here.