### PR TITLE
Let user pick a syntax color theme in Gold's style config

### DIFF
--- a/cmd/gold/dark.json
+++ b/cmd/gold/dark.json
@@ -18,7 +18,8 @@
     "color": "200"
   },
   "code_block": {
-    "color": "200"
+    "color": "200",
+    "theme": "solarized-dark"
   },
   "emph": {
     "italic": true

--- a/gold.go
+++ b/gold.go
@@ -427,7 +427,14 @@ func (tr *TermRenderer) RenderNode(w io.Writer, node *bf.Node, entering bool) bf
 
 	for _, f := range e.Fragments {
 		if node.Type == bf.CodeBlock {
-			err := quick.Highlight(w, f.Token, string(node.CodeBlockData.Info), "terminal16m", "monokai")
+			theme := "monokai"
+			if rules, ok := tr.style[f.Style]; ok {
+				if len(rules.Theme) > 0 {
+					theme = rules.Theme
+				}
+			}
+
+			err := quick.Highlight(w, f.Token, string(node.CodeBlockData.Info), "terminal16m", theme)
 			if err == nil {
 				continue
 			}

--- a/style.go
+++ b/style.go
@@ -46,6 +46,7 @@ type ElementStyle struct {
 	Overlined       bool   `json:"overlined"`
 	Inverse         bool   `json:"inverse"`
 	Blink           bool   `json:"blink"`
+	Theme           string `json:"theme"`
 }
 
 func keyToType(key string) (StyleType, error) {


### PR DESCRIPTION
Valid codeblock themes are:

abap
algol
algol_nu
api
arduino
autumn
borland
bw
colorful
dracula
emacs
friendly
fruity
github
igor
lovelace
manni
monokai
monokailight
murphy
native
paraiso-dark
paraiso-light
pastie
perldoc
pygments
rainbow_dash
rrt
solarized-dark256
solarized-dark
solarized-light
swapoff
tango
trac
vim
vs
xcode