### PR TITLE
Word-wrap text at 100 chars per default

### DIFF
--- a/cmd/gold/main.go
+++ b/cmd/gold/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"github.com/mattn/go-isatty"
+	"github.com/mitchellh/go-wordwrap"
 	"github.com/spf13/cobra"
 
 	"github.com/charmbracelet/gold"
@@ -25,7 +26,9 @@ var (
 		SilenceUsage:  false,
 		RunE:          execute,
 	}
+
 	style string
+	width uint
 )
 
 func readerFromArg(s string) (io.ReadCloser, error) {
@@ -91,7 +94,7 @@ func execute(cmd *cobra.Command, args []string) error {
 	}
 
 	out := r.RenderBytes(b)
-	fmt.Printf("%s", string(out))
+	fmt.Printf("%s", wordwrap.WrapString(string(out), width))
 	return nil
 }
 
@@ -103,4 +106,5 @@ func main() {
 
 func init() {
 	rootCmd.Flags().StringVarP(&style, "style", "s", "dark.json", "style JSON path")
+	rootCmd.Flags().UintVarP(&width, "width", "w", 100, "word-wrap at width")
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/alecthomas/chroma v0.7.0
 	github.com/logrusorgru/aurora v0.0.0-20191017060258-dc85c304c434
 	github.com/mattn/go-isatty v0.0.10
+	github.com/mitchellh/go-wordwrap v1.0.0
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/spf13/cobra v0.0.5
 	gopkg.in/russross/blackfriday.v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
+github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229/go.mod h1:0aYXnNPJ8l7uZxf45rWW1a/uME32OF0rhiYGNQ2oF2E=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=


### PR DESCRIPTION
The default can be overwritten by the user:

./gold -w 80

Fixes #23.