### PR TITLE
Fix word-wrapping in colored output

### DIFF
--- a/cmd/gold/main.go
+++ b/cmd/gold/main.go
@@ -10,7 +10,7 @@ import (
 	"os"
 
 	"github.com/mattn/go-isatty"
-	"github.com/mitchellh/go-wordwrap"
+	"github.com/muesli/go-wordwrap"
 	"github.com/spf13/cobra"
 
 	"github.com/charmbracelet/gold"

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/logrusorgru/aurora v0.0.0-20191017060258-dc85c304c434
 	github.com/mattn/go-isatty v0.0.10
 	github.com/microcosm-cc/bluemonday v1.0.2
-	github.com/mitchellh/go-wordwrap v1.0.0
+	github.com/muesli/go-wordwrap v1.0.1-0.20191125090158-10bc5504e2a8
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/spf13/cobra v0.0.5
 	gopkg.in/russross/blackfriday.v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -45,9 +45,9 @@ github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcME
 github.com/microcosm-cc/bluemonday v1.0.2 h1:5lPfLTTAvAbtS0VqT+94yOtFnGfUWYyx0+iToC3Os3s=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
-github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/muesli/go-wordwrap v1.0.1-0.20191125090158-10bc5504e2a8 h1:pkJGPjqhekH0hq/lJABlh5EhzU7eU/+VdFq9ZMOae2E=
+github.com/muesli/go-wordwrap v1.0.1-0.20191125090158-10bc5504e2a8/go.mod h1:isHWaQQfvQ38DUiq7ugbuPZowGJ+9gPmACGc3tDUN4M=
 github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229/go.mod h1:0aYXnNPJ8l7uZxf45rWW1a/uME32OF0rhiYGNQ2oF2E=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/gold.go
+++ b/gold.go
@@ -433,7 +433,7 @@ func (tr *TermRenderer) RenderNode(w io.Writer, node *bf.Node, entering bool) bf
 
 	for _, f := range e.Fragments {
 		if node.Type == bf.CodeBlock {
-			theme := ""
+			var theme string
 			if rules, ok := tr.style[f.Style]; ok {
 				if len(rules.Theme) > 0 {
 					theme = rules.Theme


### PR DESCRIPTION
ANSI codes broke the internal word-wrapping calculation. I forked the go-wordwrap package and made it ANSI-code aware. I'll probably end up rewriting this package in the near future.