### PR TITLE
Clean up pre/post ambiguity

### DIFF
--- a/baselement.go
+++ b/baselement.go
@@ -10,19 +10,19 @@ import (
 )
 
 type BaseElement struct {
-	Token string
-	Pre   string
-	Post  string
-	Style StyleType
+	Token  string
+	Prefix string
+	Suffix string
+	Style  StyleType
 }
 
 func (e *BaseElement) Render(w io.Writer, node *bf.Node, tr *TermRenderer) error {
-	if e.Pre != "" {
-		fmt.Fprintf(w, "%s", e.Pre)
+	if e.Prefix != "" {
+		fmt.Fprintf(w, "%s", e.Prefix)
 	}
 	defer func() {
-		if e.Post != "" {
-			fmt.Fprintf(w, "%s", e.Post)
+		if e.Suffix != "" {
+			fmt.Fprintf(w, "%s", e.Suffix)
 		}
 	}()
 

--- a/elements.go
+++ b/elements.go
@@ -13,8 +13,8 @@ type ElementRenderer interface {
 }
 
 type Element struct {
-	Pre      string
-	Post     string
+	Entering string
+	Exiting  string
 	Renderer ElementRenderer
 }
 
@@ -28,8 +28,8 @@ func (tr *TermRenderer) NewElement(node *bf.Node) Element {
 		}
 	case bf.BlockQuote:
 		return Element{
-			Pre:  "\n",
-			Post: "\n",
+			Entering: "\n",
+			Exiting:  "\n",
 			Renderer: &BaseElement{
 				Token: string(node.Literal),
 				Style: BlockQuote,
@@ -45,18 +45,18 @@ func (tr *TermRenderer) NewElement(node *bf.Node) Element {
 		}
 	case bf.Paragraph:
 		return Element{
-			Post:     "\n",
+			Exiting:  "\n",
 			Renderer: &ParagraphElement{},
 		}
 	case bf.Heading:
 		return Element{
-			Post:     "\n",
+			Exiting:  "\n",
 			Renderer: &HeadingElement{},
 		}
 	case bf.HorizontalRule:
 		return Element{
-			Pre:  "\n",
-			Post: "\n",
+			Entering: "\n",
+			Exiting:  "\n",
 			Renderer: &BaseElement{
 				Token: "---",
 				Style: HorizontalRule,
@@ -107,8 +107,8 @@ func (tr *TermRenderer) NewElement(node *bf.Node) Element {
 		}
 	case bf.CodeBlock:
 		return Element{
-			Pre:  "\n",
-			Post: "\n",
+			Entering: "\n",
+			Exiting:  "\n",
 			Renderer: &CodeBlockElement{
 				Code:     string(node.Literal),
 				Language: string(node.CodeBlockData.Info),
@@ -116,7 +116,7 @@ func (tr *TermRenderer) NewElement(node *bf.Node) Element {
 		}
 	case bf.Softbreak:
 		return Element{
-			Post: "\n",
+			Exiting: "\n",
 			Renderer: &BaseElement{
 				Token: string(node.Literal),
 				Style: Softbreak,
@@ -124,7 +124,7 @@ func (tr *TermRenderer) NewElement(node *bf.Node) Element {
 		}
 	case bf.Hardbreak:
 		return Element{
-			Post: "\n",
+			Exiting: "\n",
 			Renderer: &BaseElement{
 				Token: string(node.Literal),
 				Style: Hardbreak,
@@ -146,8 +146,8 @@ func (tr *TermRenderer) NewElement(node *bf.Node) Element {
 		}
 	case bf.Table:
 		return Element{
-			Pre:  "\n",
-			Post: "\n",
+			Entering: "\n",
+			Exiting:  "\n",
 		}
 	case bf.TableCell:
 		return Element{}
@@ -157,8 +157,8 @@ func (tr *TermRenderer) NewElement(node *bf.Node) Element {
 		return Element{}
 	case bf.TableRow:
 		return Element{
-			Pre:  "\n",
-			Post: "\n",
+			Entering: "\n",
+			Exiting:  "\n",
 		}
 
 	default:

--- a/gold.go
+++ b/gold.go
@@ -82,11 +82,11 @@ func (tr *TermRenderer) RenderBytes(in []byte) []byte {
 func (tr *TermRenderer) RenderNode(w io.Writer, node *bf.Node, entering bool) bf.WalkStatus {
 	// fmt.Fprintf(w, "%s %t", node.Type, entering)
 	e := tr.NewElement(node)
-	if entering && e.Pre != "" {
-		fmt.Fprintf(w, "%s", e.Pre)
+	if entering && e.Entering != "" {
+		fmt.Fprintf(w, "%s", e.Entering)
 	}
-	if !entering && e.Post != "" {
-		fmt.Fprintf(w, "%s", e.Post)
+	if !entering && e.Exiting != "" {
+		fmt.Fprintf(w, "%s", e.Exiting)
 	}
 	if isChild(node) {
 		return bf.GoToNext

--- a/heading.go
+++ b/heading.go
@@ -18,9 +18,9 @@ func (e *HeadingElement) Render(w io.Writer, node *bf.Node, tr *TermRenderer) er
 	}
 
 	el := &BaseElement{
-		Pre:   pre,
-		Token: fmt.Sprintf("%s %s", strings.Repeat("#", node.HeadingData.Level), node.FirstChild.Literal),
-		Style: Heading,
+		Prefix: pre,
+		Token:  fmt.Sprintf("%s %s", strings.Repeat("#", node.HeadingData.Level), node.FirstChild.Literal),
+		Style:  Heading,
 	}
 	return el.Render(w, node, tr)
 }

--- a/image.go
+++ b/image.go
@@ -19,10 +19,10 @@ func (e *ImageElement) Render(w io.Writer, node *bf.Node, tr *TermRenderer) erro
 	}
 	if len(node.LinkData.Destination) > 0 {
 		el := &BaseElement{
-			Token: resolveRelativeURL(tr.BaseURL, string(node.LinkData.Destination)),
-			Pre:   " [Image: ",
-			Post:  "]",
-			Style: Link,
+			Token:  resolveRelativeURL(tr.BaseURL, string(node.LinkData.Destination)),
+			Prefix: " [Image: ",
+			Suffix: "]",
+			Style:  Link,
 		}
 		el.Render(w, node, tr)
 	}

--- a/link.go
+++ b/link.go
@@ -25,10 +25,10 @@ func (e *LinkElement) Render(w io.Writer, node *bf.Node, tr *TermRenderer) error
 	}
 	if len(node.LinkData.Destination) > 0 {
 		el := &BaseElement{
-			Token: resolveRelativeURL(tr.BaseURL, string(node.LinkData.Destination)),
-			Pre:   " (",
-			Post:  ")",
-			Style: Link,
+			Token:  resolveRelativeURL(tr.BaseURL, string(node.LinkData.Destination)),
+			Prefix: " (",
+			Suffix: ")",
+			Style:  Link,
 		}
 		el.Render(w, node, tr)
 	}

--- a/list.go
+++ b/list.go
@@ -16,9 +16,9 @@ func (e *ListElement) Render(w io.Writer, node *bf.Node, tr *TermRenderer) error
 	}
 
 	el := &BaseElement{
-		Pre:   pre,
-		Token: string(node.Literal),
-		Style: List,
+		Prefix: pre,
+		Token:  string(node.Literal),
+		Style:  List,
 	}
 	return el.Render(w, node, tr)
 }

--- a/listitem.go
+++ b/listitem.go
@@ -21,9 +21,9 @@ func (e *ItemElement) Render(w io.Writer, node *bf.Node, tr *TermRenderer) error
 	}
 
 	el := &BaseElement{
-		Pre:   strings.Repeat("  ", l-1) + "• ",
-		Token: string(node.Literal),
-		Style: Item,
+		Prefix: strings.Repeat("  ", l-1) + "• ",
+		Token:  string(node.Literal),
+		Style:  Item,
 	}
 	return el.Render(w, node, tr)
 }

--- a/paragraph.go
+++ b/paragraph.go
@@ -16,9 +16,9 @@ func (e *ParagraphElement) Render(w io.Writer, node *bf.Node, tr *TermRenderer) 
 	}
 
 	el := &BaseElement{
-		Pre:   pre,
-		Token: string(node.Literal),
-		Style: Paragraph,
+		Prefix: pre,
+		Token:  string(node.Literal),
+		Style:  Paragraph,
 	}
 	return el.Render(w, node, tr)
 }


### PR DESCRIPTION
`BaseElement`'s `Prefix` and `Suffix` get printed right before and after rendering, while `Entering` and `Exiting` are printed when entering / exiting a `Node` during rendering.