### PR TITLE
Add image_text style, which lets you change the look of an image's name/alt

### DIFF
--- a/image.go
+++ b/image.go
@@ -13,7 +13,7 @@ func (e *ImageElement) Render(w io.Writer, node *bf.Node, tr *TermRenderer) erro
 	if len(node.LastChild.Literal) > 0 {
 		el := &BaseElement{
 			Token: string(node.LastChild.Literal),
-			Style: Image,
+			Style: ImageText,
 		}
 		err := el.Render(w, node.LastChild, tr)
 		if err != nil {
@@ -23,9 +23,8 @@ func (e *ImageElement) Render(w io.Writer, node *bf.Node, tr *TermRenderer) erro
 	if len(node.LinkData.Destination) > 0 {
 		el := &BaseElement{
 			Token:  resolveRelativeURL(tr.BaseURL, string(node.LinkData.Destination)),
-			Prefix: " [Image: ",
-			Suffix: "]",
-			Style:  Link,
+			Prefix: " ",
+			Style:  Image,
 		}
 		err := el.Render(w, node, tr)
 		if err != nil {

--- a/link.go
+++ b/link.go
@@ -32,8 +32,7 @@ func (e *LinkElement) Render(w io.Writer, node *bf.Node, tr *TermRenderer) error
 	if len(node.LinkData.Destination) > 0 {
 		el := &BaseElement{
 			Token:  resolveRelativeURL(tr.BaseURL, string(node.LinkData.Destination)),
-			Prefix: " (",
-			Suffix: ")",
+			Prefix: " ",
 			Style:  Link,
 		}
 		err := el.Render(w, node, tr)

--- a/style.go
+++ b/style.go
@@ -20,6 +20,7 @@ const (
 	Link
 	LinkText
 	Image
+	ImageText
 	Text
 	HTMLBlock
 	CodeBlock
@@ -79,6 +80,8 @@ func keyToType(key string) (StyleType, error) {
 		return LinkText, nil
 	case "image":
 		return Image, nil
+	case "image_text":
+		return ImageText, nil
 	case "text":
 		return Text, nil
 	case "html_block":


### PR DESCRIPTION
Removed the default values, so each style can set that individually.