### PR TITLE
Traverse parent/child directories and search for a README source

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,18 @@ glow -s mystyle.json
 Check out the [Glamour Style Section](https://github.com/charmbracelet/glamour/blob/master/styles/gallery/README.md)
 to find more styles. Or [make your own](https://github.com/charmbracelet/glamour/tree/master/styles)!
 
+### Directory Walk
+
+You can walk the directory looking for README and README.md files with the `-k` or `--walk` flag (`false` being the default):
+
+```bash
+glow --walk <path>
+```
+
+```bash
+glow -k <path>
+```
+
 ***
 
 For additional usage details see:

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ var (
 	pager       bool
 	style       string
 	width       uint
+	walk		bool
 
 	rootCmd = &cobra.Command{
 		Use:           "glow SOURCE",
@@ -41,7 +42,7 @@ type Source struct {
 	URL    string
 }
 
-func readerFromArg(s string) (*Source, error) {
+func readerFromArg(cmd *cobra.Command, s string) (*Source, error) {
 	if s == "-" {
 		return &Source{reader: os.Stdin}, nil
 	}
@@ -92,16 +93,21 @@ func readerFromArg(s string) (*Source, error) {
 			}
 		}
 
-		filepath.Walk(s,
-			func(path string, info os.FileInfo, err error) error {
-			if strings.Contains(path, "README") {
-				fmt.Println(path)
-			}
+		// walk directory
+		if cmd.Flags().Changed("walk") {
+			filepath.Walk(s,
+				func(path string, info os.FileInfo, err error) error {
+				if strings.Contains(path, "README") {
+					fmt.Println(path)
+				}
 
-			return nil
-		})
+				return nil
+			})
 
-		return nil, errors.New("missing markdown source")
+			fmt.Println("Info: possible markdown sources")
+		}
+
+		return nil, errors.New("missing markdown source in current directory")
 	}
 
 	r, err := os.Open(s)
@@ -116,7 +122,7 @@ func execute(cmd *cobra.Command, args []string) error {
 	}
 
 	// create an io.Reader from the markdown source in cli-args
-	src, err := readerFromArg(arg)
+	src, err := readerFromArg(cmd, arg)
 	if err != nil {
 		return err
 	}
@@ -204,4 +210,5 @@ func init() {
 	rootCmd.Flags().BoolVarP(&pager, "pager", "p", false, "display with pager")
 	rootCmd.Flags().StringVarP(&style, "style", "s", "dark", "style name or JSON path")
 	rootCmd.Flags().UintVarP(&width, "width", "w", 100, "word-wrap at width")
+	rootCmd.Flags().BoolVarP(&walk, "walk", "k", false, "find README file in directory")
 }

--- a/main.go
+++ b/main.go
@@ -92,6 +92,15 @@ func readerFromArg(s string) (*Source, error) {
 			}
 		}
 
+		filepath.Walk(s,
+			func(path string, info os.FileInfo, err error) error {
+			if strings.Contains(path, "README") {
+				fmt.Println(path)
+			}
+
+			return nil
+		})
+
 		return nil, errors.New("missing markdown source")
 	}
 

--- a/main.go
+++ b/main.go
@@ -25,8 +25,8 @@ var (
 	readmeNames = []string{"README.md", "README"}
 	pager       bool
 	style       string
+	walk	    bool
 	width       uint
-	walk		bool
 
 	rootCmd = &cobra.Command{
 		Use:           "glow SOURCE",


### PR DESCRIPTION
Add directory walk to look for README files in case the user is not in the root directory or the README is located in a subdirectory.