### PR TITLE
Enable ANSI for Windows consoles

### DIFF
--- a/console_windows.go
+++ b/console_windows.go
@@ -1,0 +1,23 @@
+// +build windows
+
+package main
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// enableAnsiColors enables support for ANSI color sequences in Windows
+// default console. Note that this only works with Windows 10.
+func enableAnsiColors() {
+	stdout := windows.Handle(os.Stdout.Fd())
+	var originalMode uint32
+
+	windows.GetConsoleMode(stdout, &originalMode)
+	windows.SetConsoleMode(stdout, originalMode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+}
+
+func init() {
+	enableAnsiColors()
+}

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/mattn/go-isatty v0.0.4
 	github.com/spf13/cobra v0.0.5
 	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 // indirect
+	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
 )


### PR DESCRIPTION
This ensures ANSI processing is enabled for glow.