### PR TITLE
Adding support for a GLAMOUR_STYLE environment variable

### DIFF
--- a/main.go
+++ b/main.go
@@ -183,7 +183,12 @@ func executeArg(cmd *cobra.Command, arg string, w io.Writer) error {
 	// initialize glamour
 	var gs glamour.TermRendererOption
 	if style == "auto" {
-		gs = glamour.WithAutoStyle()
+		envStyle := os.Getenv("GLAMOUR_STYLE")
+		if len(envStyle) > 0 {
+			gs = glamour.WithStylePath(envStyle)
+		} else {
+			gs = glamour.WithAutoStyle()
+		}
 	} else {
 		gs = glamour.WithStylePath(style)
 	}


### PR DESCRIPTION
A couple of CLI programs I use (e.g. https://github.com/sharkdp/bat#highlighting-theme) have support for defining the highlight/syntax theme via an environment variable. This PR adds similar functionality to Glow via a `GLAMOUR_STYLE` environment variable.

I propose the variable be named `GLAMOUR_STYLE` and any program using the Glamour library can honor the same variable to make configurations portable (I briefly entertained the idea of checking the environment variable in the `glamour` package instead of in Glow since that would automatically add the functionality to any projects that use `glamour` but I wasn’t sure if that was a good fit).