### PR TITLE
Generate new URL string for each entry in `readmeNames`

### DIFF
--- a/github.go
+++ b/github.go
@@ -28,18 +28,17 @@ func findGitHubREADME(s string) (*source, error) {
 		return nil, err
 	}
 	u.Host = "raw.githubusercontent.com"
-
+	u.Path += "/master/"
 	for _, r := range readmeNames {
-		v := u
-		v.Path += "/master/" + r
+		v := u.String() + r
 
-		resp, err := http.Get(v.String())
+		resp, err := http.Get(v)
 		if err != nil {
 			return nil, err
 		}
 
 		if resp.StatusCode == http.StatusOK {
-			return &source{resp.Body, v.String()}, nil
+			return &source{resp.Body, v}, nil
 		}
 	}
 

--- a/gitlab.go
+++ b/gitlab.go
@@ -27,18 +27,17 @@ func findGitLabREADME(s string) (*source, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	u.Path += "/raw/master/"
 	for _, r := range readmeNames {
-		v := u
-		v.Path += "/raw/master/" + r
+		v := u.String() + r
 
-		resp, err := http.Get(v.String())
+		resp, err := http.Get(v)
 		if err != nil {
 			return nil, err
 		}
 
 		if resp.StatusCode == http.StatusOK {
-			return &source{resp.Body, v.String()}, nil
+			return &source{resp.Body, v}, nil
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ var (
 	Version   = ""
 	CommitSHA = ""
 
-	readmeNames = []string{"README.md", "README"}
+	readmeNames = []string{"readme.md", "README.md", "README", "readme"}
 	pager       bool
 	style       string
 	width       uint


### PR DESCRIPTION
The code in `github.go` and `gitlab.go` mutates the same URL path
making anything but the first attempt incorrect. This means the project
at the moment only works for repositories that have `README.md` present.

I added a debug log to `findGithubREADME` and tried to get the readme
of one of my own projects (it has a readme.md)

here is the output:

```shell
$ go run . github.com/angadgill92/clean
TRYING PATH  /angadgill92/clean/master/README.md
TRYING PATH  /angadgill92/clean/master/README.md/master/README
Error: can't find README in GitHub repository
Usage:
  glow SOURCE [flags]

Flags:
  -h, --help           help for glow
  -p, --pager          display with pager
  -s, --style string   style name or JSON path (default "auto")
      --version        version for glow
  -w, --width uint     word-wrap at width

exit status 255
```

The reason for this is that we're doing
```go
   v := u
   v.Path += "/master/" + r
```

and on every iteration of the loop it adds `"/master/" + r` to
whatever URL was generated in the last iteration. This makes
every URL generated by `glow` after the first one invalid causing
the error.

Also fixes #134 🙂 