### PR TITLE
Use GitHub/GitLab API to get a repo readme

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -1,11 +1,20 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
 )
+
+// gitLabRepo contains information about a GitLab repo
+type gitLabRepo struct {
+	Branch    string `json:"default_branch"`
+	ReadmeURL string `json:"readme_url"`
+}
 
 // isGitLabURL tests a string to determine if it is a well-structured GitLab URL
 func isGitLabURL(s string) (string, bool) {
@@ -22,24 +31,44 @@ func isGitLabURL(s string) (string, bool) {
 }
 
 // findGitLabREADME tries to find the correct README filename in a repository
-func findGitLabREADME(s string) (*source, error) {
-	u, err := url.ParseRequestURI(s)
+func findGitLabREADME(repoURL string) (*source, error) {
+	user, repo, err := userAndRepoFromURL(repoURL)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, r := range readmeNames {
-		v := u
-		v.Path += "/raw/master/" + r
+	apiRepoURL := fmt.Sprintf("https://gitlab.com/api/v4/projects/%s%s%s", user, "%2F", repo)
 
-		resp, err := http.Get(v.String())
-		if err != nil {
-			return nil, err
-		}
+	resp, err := http.Get(apiRepoURL)
+	if err != nil {
+		return nil, err
+	}
 
-		if resp.StatusCode == http.StatusOK {
-			return &source{resp.Body, v.String()}, nil
-		}
+	content, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	repoInfo := gitLabRepo{}
+
+	if err := json.Unmarshal([]byte(string(content)), &repoInfo); err != nil {
+		return nil, err
+	}
+
+	file := strings.Split(repoInfo.ReadmeURL, "/")[8]
+
+	rawReadmeURL := fmt.Sprintf("%s/-/raw/%s/%s", repoURL, repoInfo.Branch, file)
+
+	resp, err = http.Get(rawReadmeURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusOK {
+		return &source{
+			reader: resp.Body,
+			URL:    repoURL,
+		}, nil
 	}
 
 	return nil, errors.New("can't find README in GitLab repository")

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"errors"
+	"net/url"
+	"strings"
+)
+
+func userAndRepoFromURL(repoURL string) (string, string, error) {
+	u, err := url.ParseRequestURI(repoURL)
+	if err != nil {
+		return "", "", err
+	}
+
+	pathSplit := strings.Split(u.Path, "/")
+
+	if len(pathSplit) != 3 || pathSplit[2] == "" {
+		return "", "", errors.New("Invalid URL format")
+	}
+
+	return pathSplit[1], pathSplit[2], nil
+}


### PR DESCRIPTION
Ref: https://github.com/charmbracelet/glow/pull/151#issuecomment-700212676

This PR adds initial support for using the GitHub/GitLab public API to get a repo readme file.

<s>
TODO:

Rate limiting:
The GitHub API [allows up to 60 requests per hour](https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#rate-limiting), in the case the user exceeds the limit, how should Glow handle it?

GitLab [allows up to 10 req per second](https://docs.gitlab.com/ee/user/gitlab_com/#haproxy-api-throttle) so it shouldn't be a problem.
</s>