### PR TITLE
Clean up and re-enable Windows workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,39 +5,33 @@ jobs:
     strategy:
       matrix:
         go-version: [1.13.x, 1.14.x, 1.15.x]
-        platform: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.platform }}
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     env:
       GO111MODULE: "on"
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go-version }}
 
-    - name: Configure git for private modules
-      env:
-        TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      run: git config --global url."https://meowgorithm:${TOKEN}@github.com".insteadOf "https://github.com"
+      - name: Checkout code
+        uses: actions/checkout@v1
 
-    - name: Install Go
-      uses: actions/setup-go@v1
-      with:
-        go-version: ${{ matrix.go-version }}
+      - name: Download Go modules
+        run: go mod download
 
-    - name: Checkout code
-      uses: actions/checkout@v1
+      - name: Build
+        run: go build -v ./...
 
-    - name: Download Go modules
-      run: go mod download
+      - name: Test
+        run: go test ./...
 
-    - name: Build
-      run: go build -v ./...
-
-    - name: Test
-      run: go test ./...
-
-    - name: Coverage
-      env:
-        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        go test -race -covermode atomic -coverprofile=profile.cov ./...
-        GO111MODULE=off go get github.com/mattn/goveralls
-        $(go env GOPATH)/bin/goveralls -coverprofile=profile.cov -service=github
-      if: matrix.go-version == '1.15.x' && matrix.platform == 'ubuntu-latest'
+      - name: Coverage
+        env:
+          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          go test -race -covermode atomic -coverprofile=profile.cov ./...
+          GO111MODULE=off go get github.com/mattn/goveralls
+          $(go env GOPATH)/bin/goveralls -coverprofile=profile.cov -service=github
+        if: matrix.go-version == '1.15.x' && matrix.platform == 'ubuntu-latest'


### PR DESCRIPTION
Fixed workflow syntax, re-enabled Windows tests and removed step for private Go modules.