### PR TITLE
Now in Scoop!

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ nix-env -iA nixpkgs.glow
 
 # FreeBSD
 pkg install glow
+
+# Windows (with Scoop)
+scoop install glow
 ```
 
 Or download a binary from the [releases][releases] page. MacOS, Linux, Windows,


### PR DESCRIPTION
[scoop](https://github.com/lukesampson/scoop) is a command-line installer for Windows.

by https://github.com/ScoopInstaller/Main/pull/1510, now we could install glow with scoop!