### PR TITLE
Ignore YAML frontmatter

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/charmbracelet/charm/ui/common"
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/glow/ui"
+	"github.com/charmbracelet/glow/utils"
 )
 
 var (
@@ -194,6 +195,8 @@ func executeArg(cmd *cobra.Command, arg string, w io.Writer) error {
 	if err != nil {
 		return err
 	}
+
+	b = utils.RemoveFrontmatter(b)
 
 	// render
 	var baseURL string

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -15,6 +15,7 @@ import (
 	"github.com/charmbracelet/charm"
 	"github.com/charmbracelet/charm/keygen"
 	"github.com/charmbracelet/charm/ui/common"
+	"github.com/charmbracelet/glow/utils"
 	"github.com/muesli/gitcha"
 	te "github.com/muesli/termenv"
 )
@@ -355,6 +356,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case fetchedMarkdownMsg:
 		m.pager.currentDocument = *msg
+		msg.Body = string(utils.RemoveFrontmatter([]byte(msg.Body)))
 		cmds = append(cmds, renderWithGlamour(m.pager, msg.Body))
 
 	case contentRenderedMsg:

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,19 @@
+package utils
+
+import "regexp"
+
+func RemoveFrontmatter(content []byte) []byte {
+	if frontmatterBoundaries := detectFrontmatter(content); frontmatterBoundaries[0] == 0 {
+		return content[frontmatterBoundaries[1]:]
+	}
+	return content
+}
+
+var yamlPattern = regexp.MustCompile(`(?m)^---\r?\n(\s*\r?\n)?`)
+
+func detectFrontmatter(c []byte) []int {
+	if matches := yamlPattern.FindAllIndex(c, 2); len(matches) > 1 {
+		return []int{matches[0][0], matches[1][1]}
+	}
+	return []int{-1, -1}
+}


### PR DESCRIPTION
Fix #146 

This PR adds 2 functions for detecting and removing YAML frontmatter.
Glow will now remove frontmatter from the content right before sending it to Glamour for rendering, it works both on the TUI and CLI.

This code is [adapted from the GitHub CLI](https://github.com/cli/cli/blob/5e89036d49993087b9b45060cc1292a18e1d853a/pkg/githubtemplate/github_template.go#L98).


Demo:

![glow](https://user-images.githubusercontent.com/6853656/97726351-0931ba00-1ac7-11eb-9bdb-fc9b51d3bf8c.gif)
