### PR TITLE
Fixed showStatusMessage(statusMessage string)

### DIFF
--- a/ui/pager.go
+++ b/ui/pager.go
@@ -387,7 +387,7 @@ func (m pagerModel) statusBarView(b *strings.Builder) {
 	// Note
 	var note string
 	if showStatusMessage {
-		note = "Stashed!"
+		note = m.statusMessage
 	} else {
 		note = m.currentDocument.Note
 		if len(note) == 0 {


### PR DESCRIPTION
`showStatusMessage(statusMessage string)` should display the string passed on the status line. Instead, "Stashed!" is hardcoded as the only string it will ever display. This fixes the behavior to work as intended.