### PR TITLE
Expand the path for a specified style file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.9
 	github.com/meowgorithm/babyenv v1.3.0
 	github.com/microcosm-cc/bluemonday v1.0.4 // indirect
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/muesli/gitcha v0.1.2-0.20200908172931-5aa4fdccf2f6
 	github.com/muesli/go-app-paths v0.2.1
 	github.com/muesli/reflow v0.2.0

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,6 +1,11 @@
 package utils
 
-import "regexp"
+import (
+	"os"
+	"regexp"
+
+	"github.com/mitchellh/go-homedir"
+)
 
 func RemoveFrontmatter(content []byte) []byte {
 	if frontmatterBoundaries := detectFrontmatter(content); frontmatterBoundaries[0] == 0 {
@@ -16,4 +21,13 @@ func detectFrontmatter(c []byte) []int {
 		return []int{matches[0][0], matches[1][1]}
 	}
 	return []int{-1, -1}
+}
+
+// Expands tilde and all environment variables from the given path.
+func ExpandPath(path string) string {
+	s, err := homedir.Expand(path)
+	if err == nil {
+		return os.ExpandEnv(s)
+	}
+	return os.ExpandEnv(path)
 }


### PR DESCRIPTION
This expands the specified path for the `style` file in the config. Supporting tilde and values from the current environment variables.

 Now can specify paths like this:
- `~/.config/glow/style.json`
- `$HOME/.config/glow/style.json`
- `${HOME}/.config/glow/style.json`

Resolves #222 