### PR TITLE
Add option to edit current document

### DIFF
--- a/ui/pager.go
+++ b/ui/pager.go
@@ -213,23 +213,6 @@ func (m pagerModel) Update(msg tea.Msg) (pagerModel, tea.Cmd) {
 			}
 		default:
 			switch msg.String() {
-			case "1":
-				m.currentDocument.Body = "Hello world"
-				cmd := m.showStatusMessage("Testing redraw + cmds")
-				cmds = append(cmds, cmd)
-				cmd = renderWithGlamour(m, m.currentDocument.Body)
-				cmds = append(cmds, cmd)
-			case "2":
-				m.currentDocument.Body = "World, hello"
-				cmd := renderWithGlamour(m, m.currentDocument.Body)
-				cmds = append(cmds, cmd)
-				cmd = m.showStatusMessage("Testing redraw + cmds")
-				cmds = append(cmds, cmd)
-			case "r":
-				cmd := m.showStatusMessage("Redrew page!")
-				cmds = append(cmds, cmd)
-				cmd = renderWithGlamour(m, m.currentDocument.Body)
-				cmds = append(cmds, cmd)
 			case "e":
 				editedDocument, err := m.editCurrentDocument()
 

--- a/ui/pager.go
+++ b/ui/pager.go
@@ -656,12 +656,13 @@ func (m pagerModel) editCurrentDocument() (string, string, error) {
 	
 	// Open the temporary file with an editor
 	err = openFileInEditor(tempFile.Name())
-	if err.Error() == "No editor found\n" {
-		return "", "Couldn't find an editor!", err
-	} else if err != nil {
+	if err != nil {
+		if err.Error() == "No editor found\n" {
+			return "", "Couldn't find an editor!", err
+		}
 		return "", "Couldn't open file in editor!", err
 	}
-	
+
 	// Get the contents of the edited file
 	b, err := ioutil.ReadFile(tempFile.Name())
 	if err != nil {

--- a/ui/pager.go
+++ b/ui/pager.go
@@ -57,6 +57,7 @@ type stashErrMsg struct{ err error }
 
 type editorContent struct {
 	content       string
+	ID            int
 	isUpdated     bool
 	statusMessage string
 }
@@ -221,7 +222,9 @@ func (m pagerModel) Update(msg tea.Msg) (pagerModel, tea.Cmd) {
 				}
 
 				if editedDocument.isUpdated {
+					// Update the current document
 					m.currentDocument.Body = editedDocument.content
+					m.currentDocument.ID = editedDocument.ID
 					cmd = renderWithGlamour(m, m.currentDocument.Body)
 					cmds = append(cmds, cmd)
 				}
@@ -668,7 +671,7 @@ func (m pagerModel) editCurrentDocument() (editorContent, error) {
 			// }
 			
 			// Create a new stash
-			_, err := m.general.cc.StashMarkdown(m.currentDocument.Note, editString)
+			newStash, err := m.general.cc.StashMarkdown(m.currentDocument.Note, editString)
 
 			if err != nil {
 				editedDocument.statusMessage = "Error creating new stash!"
@@ -682,6 +685,7 @@ func (m pagerModel) editCurrentDocument() (editorContent, error) {
 				} else {
 					editedDocument.isUpdated = true
 					editedDocument.content = editString
+					editedDocument.ID = newStash.ID
 					editedDocument.statusMessage = "Updated stash!"
 					return editedDocument, nil
 				}

--- a/ui/pager.go
+++ b/ui/pager.go
@@ -55,10 +55,6 @@ type noteSavedMsg *charm.Markdown
 type stashSuccessMsg markdown
 type stashErrMsg struct{ err error }
 
-type editorErrMsg struct{
-	err           error
-	statusMessage string
-}
 type editorContent struct {
 	content       string
 	isUpdated     bool
@@ -66,7 +62,6 @@ type editorContent struct {
 }
 
 func (s stashErrMsg) Error() string { return s.err.Error() }
-func (s editorErrMsg) Error() string { return s.err.Error() }
 
 type pagerState int
 
@@ -578,7 +573,7 @@ func glamourRender(m pagerModel, markdown string) (string, error) {
 
 // ETC
 
-// Returns a file descriptor for a temporary file
+// Returns a file descriptor for a temporary file.
 func createTemporaryCopy(content string) (*os.File, error) {
 	tempFile, err := ioutil.TempFile("", "glow-")
 	if err != nil {
@@ -614,7 +609,7 @@ func openFileInEditor(filePath string) (error) {
 	return nil
 }
 
-// Returns the edits made and a message to display
+// Returns the edits made and a message to display.
 func (m pagerModel) editCurrentDocument() (editorContent, error) {
 	editedDocument := editorContent{
 		content:       "",
@@ -624,11 +619,11 @@ func (m pagerModel) editCurrentDocument() (editorContent, error) {
 
 	// Copy the contents of the document to a temporary file
 	tempFile, err := createTemporaryCopy(m.currentDocument.Body)
-	defer tempFile.Close()
 	if err != nil {
 		editedDocument.statusMessage = "Error opening temporary file!"
 		return editedDocument, err
 	}
+	defer tempFile.Close()
 	
 	// Open the temporary file with an editor
 	err = openFileInEditor(tempFile.Name())

--- a/ui/pager.go
+++ b/ui/pager.go
@@ -595,37 +595,6 @@ func glamourRender(m pagerModel, markdown string) (string, error) {
 
 // ETC
 
-// Returns an editor path or error.
-func getEditor() (string, error) {
-        var editor_path string
-        var editor_err error
-
-        editors := []string{"nvim", "nano", "vim", "vi", "gedit"}
-
-        // If $EDITOR is set, prepend it to the list of editors we'll search for
-        if os.Getenv("EDITOR") != "" {
-                editors = append([]string{os.Getenv("EDITOR")}, editors...)
-        }
-
-        // By default, the error should be that no command has been found
-        editor_err = fmt.Errorf("No editor found")
-
-        // Search for the editors, stopping after the first one is found
-        for i := 0; i < len(editors) && editor_path == ""; i++ {
-                // Look for the editor in $PATH
-                path, err := exec.LookPath(editors[i]);
-
-                if err == nil {
-                        // If it was found, store the path (exiting the loop)...
-                        editor_path = path
-                        // ...and set the error to nil
-                        editor_err = nil
-                }
-        }
-
-        return editor_path, editor_err
-}
-
 // Returns a file descriptor for a temporary file
 func createTemporaryCopy(content string) (*os.File, error) {
 	tempFile, err := ioutil.TempFile("", "glow-")
@@ -642,16 +611,16 @@ func createTemporaryCopy(content string) (*os.File, error) {
 }
 
 func openFileInEditor(filePath string) (error) {
-	editorPath, err := getEditor()
-	if err != nil {
-		return err
+	editorPath := os.Getenv("EDITOR")
+	if editorPath == "" {
+		return fmt.Errorf("EDITOR not set")
 	}
 	
 	cmd := exec.Command(editorPath, filePath)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	err = cmd.Start()
+	err := cmd.Start()
 	if err != nil {
 		return err
 	}

--- a/ui/pager.go
+++ b/ui/pager.go
@@ -387,7 +387,7 @@ func (m pagerModel) statusBarView(b *strings.Builder) {
 	// Note
 	var note string
 	if showStatusMessage {
-		note = "Stashed!"
+		note = m.statusMessage
 	} else {
 		note = m.currentDocument.Note
 		if len(note) == 0 {

--- a/ui/pager.go
+++ b/ui/pager.go
@@ -680,9 +680,13 @@ func (m pagerModel) editCurrentDocument() (editorContent, error) {
 			// err := m.general.cc.SetMarkdownBody(m.currentDocument.ID, editString)
 
 			// if err != nil {
-			// 	return "", "Error updating stash!", err
+			//  editedDocument.statusMessage = "Error updating stash!"
+			//  return editedDocument, err
 			// } else {
-			// 	return editString, "Updated stash!", nil
+			//  editedDocument.isUpdated = true
+			//  editedDocument.content = editString
+			//  editedDocument.statusMessage = "Updated stash!"
+			//  return editedDocument, nil
 			// }
 			
 			// Create a new stash

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -408,6 +408,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			md := markdown(msg)
 			_ = m.stash.replaceLocalMarkdown(md.localPath, &md)
 		}
+
+	// Update the stash ID after editing a document
+	case contentEdited:
+		if msg.updatedStash {
+			for i := range m.stash.markdowns {
+				if m.stash.markdowns[i].ID == msg.oldID {
+					m.stash.markdowns[i].ID = msg.newID
+					m.stash.markdowns[i].CreatedAt = time.Now()
+				}
+			}
+		}
 	}
 
 	// Process children


### PR DESCRIPTION
Implements charmbracelet/glow#182

Allows the user to edit the current document by typing 'e'. If `$EDITOR` is set, a temporary file is created with the contents of the current document, and the specified editor is used to open it. If no changes are made when the editor exits, nothing happens. If changes *are* made, then:

**if** the document is a local file, the edits are written to that file
**if** the document is stashed, a new stash is created with the edits, and the old stash is deleted.

It would be ideal to simply update the contents of a stash, but the charm API doesn't currently allow this. Deleting the selected stash has the side effect that, when the user returns to the list of files and tries to re-open the same document, the stash won't load. Restarting `glow` solves this and shows the newly created, updated stash.

https://github.com/charmbracelet/charm/pull/13 creates a `SetMarkdownBody()` method to resolve this minor issue.