### PR TITLE
Open TUI at given path if first argument is a directory

### DIFF
--- a/stash_cmd.go
+++ b/stash_cmd.go
@@ -27,7 +27,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			initConfig()
 			if len(args) == 0 {
-				return runTUI(true)
+				return runTUI("", true)
 			}
 
 			filePath := args[0]

--- a/ui/config.go
+++ b/ui/config.go
@@ -8,6 +8,9 @@ type Config struct {
 	GlamourMaxWidth uint
 	GlamourStyle    string
 
+	// Which directory should we start from?
+	WorkingDirectory string
+
 	// Which document types shall we show?
 	DocumentTypes DocTypeSet
 

--- a/ui/config.go
+++ b/ui/config.go
@@ -8,7 +8,7 @@ type Config struct {
 	GlamourMaxWidth uint
 	GlamourStyle    string
 
-	// Which document types shall we show? We work though this with bitmasking.
+	// Which document types shall we show?
 	DocumentTypes DocTypeSet
 
 	// For debugging the UI

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -493,12 +494,31 @@ func errorView(err error, fatal bool) string {
 
 func findLocalFiles(m model) tea.Cmd {
 	return func() tea.Msg {
-		cwd, err := os.Getwd()
+		var (
+			cwd = m.common.cfg.WorkingDirectory
+			err error
+		)
+
+		if cwd == "" {
+			cwd, err = os.Getwd()
+		} else {
+			var info os.FileInfo
+			info, err = os.Stat(cwd)
+			if err == nil && info.IsDir() {
+				cwd, err = filepath.Abs(cwd)
+			}
+		}
+
+		// Note that this is one error check for both cases above
 		if err != nil {
 			if debug {
 				log.Println("error finding local files:", err)
 			}
 			return errMsg{err}
+		}
+
+		if debug {
+			log.Println("local directory is:", cwd)
 		}
 
 		var ignore []string


### PR DESCRIPTION
This PR opens a TUI at the given path if the first argument is a directory.

This will open the Glow TUI:

```bash
glow ~
glow ./path/to/whatever
```

But this will attempt to open a markdown file:

```bash
glow ./path/to/README.md
glow github.com/charmbracelet/glow
```

See #234.