### PR TITLE
feat: snapcraft packages and improved goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,9 +3,9 @@ env:
   - CGO_ENABLED=0
 before:
   hooks:
-    - go mod download
+    - go mod tidy
 builds:
-  - id: "glow"
+  -
     binary: glow
     ldflags: -s -w -X main.Version={{ .Version }} -X main.CommitSHA={{ .Commit }}
     goos:
@@ -24,7 +24,7 @@ builds:
       - 7
 
 archives:
-  - id: default
+  -
     builds:
       - glow
     format_overrides:
@@ -37,9 +37,7 @@ archives:
       amd64: x86_64
 
 nfpms:
-  - builds:
-      - glow
-
+  -
     vendor: charmbracelet
     homepage: "https://charm.sh/"
     maintainer: "Christian Muehlhaeuser <muesli@gmail.com>"
@@ -62,6 +60,25 @@ brews:
     homepage: "https://charm.sh/"
     description: "Render markdown on the CLI"
     # skip_upload: true
+
+snapcrafts:
+  -
+    name: glow
+    publish: true
+    summary: Render markdown on the CLI, with pizzazz!
+    description: |
+      Glow is a terminal based markdown reader designed from the ground up to bring out the beauty—and power—of the CLI.
+      Use it to discover markdown files, read documentation directly on the command line and stash markdown files to your own private collection so you can read them anywhere. Glow will find local markdown files in subdirectories or a local Git repository.
+      By the way, all data stashed is encrypted end-to-end: only you can decrypt it. More on that below.
+
+    grade: stable
+    confinement: strict
+    license: MIT
+    base: core20
+
+    apps:
+      glow:
+        plugs: ["home", "network"]
 
 signs:
   - artifacts: checksum


### PR DESCRIPTION
- snap config based on https://github.com/tbille/glow-snap
- simplified goreleaser config a bit
  - go mod tidy instead of download
  - remove unneeded ids/filters

Tested with

```
goreleaser --rm-dist --skip-validate --skip-publish
```

unfortunately it seems impossible to test the actual snap in a docker container... maybe someone with a ubuntu machine can validate?