### PR TITLE
Always use latest version of golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,7 @@
 name: lint
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
 
 jobs:
   golangci:
@@ -10,11 +12,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.30
           # Optional: golangci-lint command line arguments.
           args: --issues-exit-code=0
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true


### PR DESCRIPTION
Specifying a version is now optional in golangci-lint-action.