### PR TITLE
Only login to snapcraft when secret is available in goreleaser workflow

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -8,26 +8,26 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: ~1.16
-      -
-        name: Set up Snapcraft
-        env:
-          SNAPCRAFT_LOGIN: ${{ secrets.SNAPCRAFT_LOGIN }}
+      - name: Set up Snapcraft
         run: |
           sudo apt-get update
           sudo apt-get -yq --no-install-suggests --no-install-recommends install snapcraft
-          snapcraft login --with <(echo "$SNAPCRAFT_LOGIN")
-      -
-        name: Run GoReleaser
+          mkdir -p $HOME/.cache/snapcraft/download
+          mkdir -p $HOME/.cache/snapcraft/stage-packages
+      - name: Login Snapcraft
+        env:
+          SNAPCRAFT_LOGIN: ${{ secrets.SNAPCRAFT_LOGIN }}
+        if: env.SNAPCRAFT_LOGIN != null
+        run: snapcraft login --with <(echo "$SNAPCRAFT_LOGIN")
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest


### PR DESCRIPTION
Prevents this workflow from failing when running in the PR-context, as the secrets aren't available.