### PR TITLE
Use golang.org/x/term

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,9 +21,9 @@ require (
 	github.com/segmentio/ksuid v1.0.3
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.7.1
-	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
+	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad // indirect
 	golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc // indirect
 	golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78
-	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf // indirect
+	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf
 	golang.org/x/text v0.3.2
 )

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 	gap "github.com/muesli/go-app-paths"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/charm/ui/common"
@@ -153,7 +153,7 @@ func validateOptions(cmd *cobra.Command) error {
 		}
 	}
 
-	isTerminal := terminal.IsTerminal(int(os.Stdout.Fd()))
+	isTerminal := term.IsTerminal(int(os.Stdout.Fd()))
 	// We want to use a special no-TTY style, when stdout is not a terminal
 	// and there was no specific style passed by arg
 	if !isTerminal && !cmd.Flags().Changed("style") {
@@ -162,7 +162,7 @@ func validateOptions(cmd *cobra.Command) error {
 
 	// Detect terminal width
 	if isTerminal && width == 0 && !cmd.Flags().Changed("width") {
-		w, _, err := terminal.GetSize(int(os.Stdout.Fd()))
+		w, _, err := term.GetSize(int(os.Stdout.Fd()))
 		if err == nil {
 			width = uint(w)
 		}


### PR DESCRIPTION
The golang.org/x/crypto/ssh/terminal package is deprecated and merely a
wrapper around golang.org/x/term. Use the latter directly and avoid a
direct dependency on the former.