### PR TITLE
docs: streamline install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,9 @@ More on that below.
 
 ## Installation
 
-Use your fave package manager:
+### Package Manager
 
 ```bash
-# go install
-go install github.com/charmbracelet/glow@latest
-
 # macOS or Linux
 brew install glow
 
@@ -67,7 +64,14 @@ Or download a binary from the [releases][releases] page. MacOS, Linux, Windows,
 FreeBSD, and OpenBSD binaries are available, as well as Debian, RPM, and Alpine
 packages. ARM builds are also available for macOS, Linux, FreeBSD, and OpenBSD.
 
-Or just build it yourself (requires Go 1.13+):
+### Go
+
+Or just install it with `go`:
+```bash
+go install github.com/charmbracelet/glow@latest
+```
+
+### Build (requires Go 1.13+)
 
 ```bash
 git clone https://github.com/charmbracelet/glow.git

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ More on that below.
 Use your fave package manager:
 
 ```bash
+# go install
+go install github.com/charmbracelet/glow@latest
+
 # macOS or Linux
 brew install glow
 


### PR DESCRIPTION
Add a note to just use `go install` for installation.

Perhaps obvious, but I tend to simply use go as a package manager for golang projects.

Edit: Also, this is just super nice; been looking for a good terminal markdown viewer and this renders beautifully, thanks!