### PR TITLE
Add MPR installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ sudo port install glow
 # Arch Linux (btw)
 pacman -S glow
 
+# makedeb Package Repository (MPR)
+git clone 'https://mpr.makedeb.org/glow'
+cd glow/
+makedeb -si
+
 # Void Linux
 xbps-install -S glow
 


### PR DESCRIPTION
The [MPR](https://mpr.makedeb.org) is a package repository for [makedeb](https://www.makedeb.org/), a built tool similar to `makepkg` found on Arch Linux.

The MPR itself is similar to the [AUR](https://aur.archlinux.org), and is just designed for Debian and Ubuntu based systems instead of Arch Linux.

I saw that there were .deb packages in the releases page, but I think the MPR could provide a benefit in providing an easier upgrade path than needing to download a new deb on every release.

You can view the MPR package for Glow [here](https://mpr.makedeb.org/packages/glow).