### PR TITLE
fix: goreleaser workflow

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,21 +7,26 @@ before:
 builds:
   -
     binary: glow
-    ldflags: -s -w -X main.Version={{ .Version }} -X main.CommitSHA={{ .Commit }}
+    ldflags: -s -w -X main.Version=v{{ .Version }} -X main.CommitSHA={{ .Commit }} -X main.CommitDate={{ .CommitDate }}
     goos:
       - linux
-      - freebsd
-      - openbsd
       - darwin
       - windows
+      - freebsd
+      - openbsd
+      - netbsd
     goarch:
       - amd64
       - arm64
-      - 386
+      - "386"
       - arm
     goarm:
-      - 6
-      - 7
+      - "7"
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: windows
+        goarm: "7"
 
 archives:
   -


### PR DESCRIPTION
copied from meta

eventually we should refactor this to use meta :)

fixes https://github.com/charmbracelet/glow/runs/7254764701?check_suite_focus=true