### PR TITLE
Remove exit message

### DIFF
--- a/main.go
+++ b/main.go
@@ -353,8 +353,6 @@ func runTUI(workingDirectory string, stashedOnly bool) error {
 		return err
 	}
 
-	// Exit message
-	fmt.Printf("\n  Thanks for using Glow!\n\n")
 	return nil
 }
 


### PR DESCRIPTION
As already discussed in https://github.com/charmbracelet/glow/issues/329
the exit message can be a bit irritating, especially when integrating
glow into scripts/etc.
PR https://github.com/charmbracelet/glow/pull/331 did more than just
remove the exit message but was since closed by the requestor.