### PR TITLE
Open Local Markdown Files in `EDITOR`

### DIFF
--- a/ui/editor.go
+++ b/ui/editor.go
@@ -1,0 +1,33 @@
+package ui
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+const defaultEditor = "nano"
+
+type editorFinishedMsg struct{ err error }
+
+func openEditor(path string) tea.Cmd {
+	editor, args := getEditor()
+	cmd := exec.Command(editor, append(args, path)...)
+	cb := func(err error) tea.Msg {
+		return editorFinishedMsg{err}
+	}
+	return tea.ExecProcess(cmd, cb)
+}
+
+func getEditor() (string, []string) {
+	editor := strings.Fields(os.Getenv("EDITOR"))
+	if len(editor) > 1 {
+		return editor[0], editor[1:]
+	}
+	if len(editor) == 1 {
+		return editor[0], []string{}
+	}
+	return defaultEditor, []string{}
+}

--- a/ui/pager.go
+++ b/ui/pager.go
@@ -283,6 +283,12 @@ func (m pagerModel) update(msg tea.Msg) (pagerModel, tea.Cmd) {
 				}
 
 				return m, textinput.Blink
+
+			case "e":
+				if m.currentDocument.docType == LocalDoc {
+					return m, openEditor(m.currentDocument.localPath)
+				}
+
 			case "s":
 				if m.common.authStatus != authOK {
 					break
@@ -340,6 +346,12 @@ func (m pagerModel) update(msg tea.Msg) (pagerModel, tea.Cmd) {
 		if m.viewport.HighPerformanceRendering {
 			cmds = append(cmds, viewport.Sync(m.viewport))
 		}
+
+	// We've finished editing the document, potentially making changes. Let's
+	// retrieve the latest version of the document so that we display
+	// up-to-date contents.
+	case editorFinishedMsg:
+		return m, loadLocalMarkdown(&m.currentDocument)
 
 	// We've reveived terminal dimensions, either for the first time or
 	// after a resize

--- a/ui/stash.go
+++ b/ui/stash.go
@@ -761,6 +761,18 @@ func (m *stashModel) handleDocumentBrowsing(msg tea.Msg) tea.Cmd {
 			}
 			m.updatePagination()
 
+		// Edit document in EDITOR
+		case "e":
+			md := m.selectedMarkdown()
+			if md == nil {
+				break
+			}
+			file := m.selectedMarkdown().localPath
+			if file == "" {
+				break
+			}
+			return openEditor(file)
+
 		// Open document
 		case keyEnter:
 			m.hideStatusMessage()


### PR DESCRIPTION
Fixes https://github.com/charmbracelet/glow/issues/182

Introduce key binding to allow users to open their `EDITOR` to edit local
markdown files in stash and pager view.
