### PR TITLE
fix: support hard line breaks

### DIFF
--- a/main.go
+++ b/main.go
@@ -271,6 +271,7 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 		gs,
 		glamour.WithWordWrap(int(width)),
 		glamour.WithBaseURL(baseURL),
+		glamour.WithPreservedNewLines(),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #212 based on @fiskhest's [comment](https://github.com/charmbracelet/glow/issues/212#issuecomment-921632355).  
Updated glamour version and added a line in `main.go` to preserve line breaks.  

### Test case:
```
$ cat test.md
two spaces  
break tag<br>
backslash\
hello world
```

### Current behavior:
```
$ glow test.md

  two spaces break tag backslash hello world

```

### After this patch:
```
$ go build
$ ./glow test.md

  two spaces
  break tag
  backslash
  hello world

```