### PR TITLE
use io or os packages instead of deprecated io/ioutil 

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -246,7 +245,7 @@ func executeArg(cmd *cobra.Command, arg string, w io.Writer) error {
 }
 
 func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
-	b, err := ioutil.ReadAll(src.reader)
+	b, err := io.ReadAll(src.reader)
 	if err != nil {
 		return err
 	}

--- a/stash_cmd.go
+++ b/stash_cmd.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path"
@@ -43,7 +43,7 @@ var (
 			}
 
 			defer f.Close()
-			b, err := ioutil.ReadAll(f)
+			b, err := io.ReadAll(f)
 			if err != nil {
 				return fmt.Errorf("error reading file")
 			}

--- a/ui/stash.go
+++ b/ui/stash.go
@@ -3,8 +3,8 @@ package ui
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -1401,7 +1401,7 @@ func loadLocalMarkdown(md *markdown) tea.Cmd {
 			return errMsg{errors.New("could not load file: missing path")}
 		}
 
-		data, err := ioutil.ReadFile(md.localPath)
+		data, err := os.ReadFile(md.localPath)
 		if err != nil {
 			if debug {
 				log.Println("error reading local markdown:", err)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -3,7 +3,6 @@ package ui
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -656,7 +655,7 @@ func stashDocument(cc *charm.Client, md markdown) tea.Cmd {
 			switch md.docType {
 
 			case LocalDoc:
-				data, err := ioutil.ReadFile(md.localPath)
+				data, err := os.ReadFile(md.localPath)
 				if err != nil {
 					if debug {
 						log.Println("error loading document body for stashing:", err)


### PR DESCRIPTION
fixes #373 

@bashbunni honestly I have no idea what's worth testing in this case, the old packages are being used as a proxy, no specific code used.

```go
// io/ioutils
func ReadAll(r io.Reader) ([]byte, error) {
	return io.ReadAll(r)
}
```

```go
// io/ioutils
func ReadFile(filename string) ([]byte, error) {
	return os.ReadFile(filename)
}
```

Not sure how to handle the go version in go.mod, feedback on that?