### PR TITLE
fix: use filepath.Dir instead of path.Dir

### DIFF
--- a/config_cmd.go
+++ b/config_cmd.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 
 	"github.com/charmbracelet/charm/ui/common"
 	gap "github.com/muesli/go-app-paths"
@@ -53,7 +54,7 @@ var configCmd = &cobra.Command{
 		if _, err := os.Stat(configFile); os.IsNotExist(err) {
 			// File doesn't exist yet, create all necessary directories and
 			// write the default config file
-			if err := os.MkdirAll(path.Dir(configFile), 0700); err != nil {
+			if err := os.MkdirAll(filepath.Dir(configFile), 0700); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
Resolves #380 

Use the `filepath` implementation of `Dir` instead of `path`. Resolve path resolution with Windows paths containing `\\` separators.

Given a `configFile` value of `"C:\\Users\\Christopher\\AppData\\Local\\glow\\Config\\glow.yml"`, `path.Dir(configFile)` resolves to a value of `"."`.

Looks like a difference in how path separators are handled by `path.Dir` and `filepath.Dir`. See https://groups.google.com/g/golang-nuts/c/UoRlbaSqtDk for additional info.