### PR TITLE
feature: Refresh local files section using 'r' in pager

### DIFF
--- a/ui/stash.go
+++ b/ui/stash.go
@@ -355,6 +355,17 @@ func (m stashModel) selectedMarkdown() *markdown {
 	return mds[i]
 }
 
+func (m *stashModel) clearMarkdownsOfType(doctype DocType) {
+	new := m.markdowns[:0]
+	for _, md := range m.markdowns {
+		if doctype != md.docType {
+			m.markdowns = append(new, md)
+		}
+	}
+	m.markdowns = new
+	m.updatePagination()
+}
+
 // Adds markdown documents to the model.
 func (m *stashModel) addMarkdowns(mds ...*markdown) {
 	if len(mds) > 0 {

--- a/ui/stashhelp.go
+++ b/ui/stashhelp.go
@@ -159,6 +159,10 @@ func (m stashModel) helpView() (string, int) {
 
 	appHelp = append(appHelp, "q", "quit")
 
+	if m.sections[m.sectionIndex].docTypes.Contains(LocalDoc) {
+		appHelp = append(appHelp, "r", "refresh")
+	}
+
 	// Detailed help
 	if m.showFullHelp {
 		if m.filterState != filtering {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -264,6 +264,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Batch(batch...)
 			}
 
+		case "r":
+			if m.stash.sections[m.stash.sectionIndex].docTypes.Contains(LocalDoc) {
+				m.stash.clearMarkdownsOfType(LocalDoc)
+				cmds = append(cmds, findLocalFiles(m))
+			}
 		case "q":
 			var cmd tea.Cmd
 


### PR DESCRIPTION
Using Glow as a dashboard into my local Markdown folder, it would be nice to be able to easily reload the folder content. 

This PR adds a simple refresh using 'r' for local files area only

<img width="303" alt="image" src="https://user-images.githubusercontent.com/3485445/201476641-a9776ab0-c0f8-4238-be4f-294fa1b4fc39.png">

![image](https://user-images.githubusercontent.com/3485445/201476701-79fd7dc5-f237-4fea-94ad-fbdc748a32df.png)

![image](https://user-images.githubusercontent.com/3485445/201476727-d2f3ae6b-611d-4c05-a353-119f0d70b6b9.png)

