### PR TITLE
Fix double close body

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,12 +83,11 @@ func sourceFromArg(arg string) (*source, error) {
 			if u.Scheme != "http" && u.Scheme != "https" {
 				return nil, fmt.Errorf("%s is not a supported protocol", u.Scheme)
 			}
-
-			resp, err := http.Get(u.String())
+			// consumer of the source is responsible for closing the ReadCloser.
+			resp, err := http.Get(u.String()) // nolint:bodyclose
 			if err != nil {
 				return nil, err
 			}
-			defer resp.Body.Close() //nolint:errcheck
 			if resp.StatusCode != http.StatusOK {
 				return nil, fmt.Errorf("HTTP status %d", resp.StatusCode)
 			}


### PR DESCRIPTION
This PR fixes an issue with the latest `glow` which double closes the response
body which prevents it from reading HTTPS links.

The `sourceFromArgs` closes the https response body and provides the body to the `source` which also closes it.

```
defer src.reader.Close()
```

This PR removes the initial closing so that the `source` can be read and
closed.
