### PR TITLE
fix: deref url and make combo of readme names

### DIFF
--- a/github.go
+++ b/github.go
@@ -29,8 +29,13 @@ func findGitHubREADME(s string) (*source, error) {
 	}
 	u.Host = "raw.githubusercontent.com"
 
+	readmeNamesCombo := make([]string, 0, len(readmeNames)*2)
 	for _, r := range readmeNames {
-		v := u
+		readmeNamesCombo = append(readmeNamesCombo, []string{r, strings.ToLower(r)}...)
+	}
+
+	for _, r := range readmeNamesCombo {
+		v := *u
 		v.Path += "/master/" + r
 
 		// nolint:bodyclose

--- a/gitlab.go
+++ b/gitlab.go
@@ -27,9 +27,13 @@ func findGitLabREADME(s string) (*source, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	readmeNamesCombo := make([]string, 0, len(readmeNames)*2)
 	for _, r := range readmeNames {
-		v := u
+		readmeNamesCombo = append(readmeNamesCombo, []string{r, strings.ToLower(r)}...)
+	}
+
+	for _, r := range readmeNamesCombo {
+		v := *u
 		v.Path += "/raw/master/" + r
 
 		// nolint:bodyclose


### PR DESCRIPTION
Resolves #434 

As well, fixes a subtle bug where the loop was using a pointer and the resulting URL was incorrect after a single iteration.