### PR TITLE
Show edit help in stash model

### DIFF
--- a/ui/pager.go
+++ b/ui/pager.go
@@ -528,10 +528,15 @@ func (m pagerModel) helpView() (s string) {
 		memoOrStash = "s       stash this document"
 	}
 
+	editOrBlank := "e       edit this document"
+	if m.currentDocument.docType != LocalDoc || m.currentDocument.localPath == "" {
+		editOrBlank = ""
+	}
+
 	col1 := []string{
 		"g/home  go to top",
 		"G/end   go to bottom",
-		"e       edit this document",
+		editOrBlank,
 		memoOrStash,
 		"esc     back to files",
 		"q       quit",

--- a/ui/stash.go
+++ b/ui/stash.go
@@ -764,7 +764,7 @@ func (m *stashModel) handleDocumentBrowsing(msg tea.Msg) tea.Cmd {
 		// Edit document in EDITOR
 		case "e":
 			md := m.selectedMarkdown()
-			if md == nil {
+			if md == nil || md.docType != LocalDoc {
 				break
 			}
 			file := m.selectedMarkdown().localPath

--- a/ui/stashhelp.go
+++ b/ui/stashhelp.go
@@ -110,9 +110,11 @@ func (m stashModel) helpView() (string, int) {
 	var (
 		isStashed     bool
 		isStashable   bool
+		isEditable    bool
 		navHelp       []string
 		filterHelp    []string
 		selectionHelp []string
+		editHelp      []string
 		sectionHelp   []string
 		appHelp       []string
 	)
@@ -121,6 +123,7 @@ func (m stashModel) helpView() (string, int) {
 		md := m.selectedMarkdown()
 		isStashed = md != nil && md.docType == StashedDoc
 		isStashable = md != nil && md.docType == LocalDoc && m.online()
+		isEditable = md != nil && md.docType == LocalDoc && md.localPath != ""
 	}
 
 	if numDocs > 0 && m.showFullHelp {
@@ -152,6 +155,10 @@ func (m stashModel) helpView() (string, int) {
 		selectionHelp = []string{"s", "stash"}
 	}
 
+	if isEditable {
+		editHelp = []string{"e", "edit"}
+	}
+
 	// If there are errors
 	if m.err != nil {
 		appHelp = append(appHelp, "!", "errors")
@@ -164,14 +171,14 @@ func (m stashModel) helpView() (string, int) {
 		if m.filterState != filtering {
 			appHelp = append(appHelp, "?", "close help")
 		}
-		return m.renderHelp(navHelp, filterHelp, selectionHelp, sectionHelp, appHelp)
+		return m.renderHelp(navHelp, filterHelp, append(selectionHelp, editHelp...), sectionHelp, appHelp)
 	}
 
 	// Mini help
 	if m.filterState != filtering {
 		appHelp = append(appHelp, "?", "more")
 	}
-	return m.renderHelp(navHelp, filterHelp, selectionHelp, sectionHelp, appHelp)
+	return m.renderHelp(navHelp, filterHelp, selectionHelp, editHelp, sectionHelp, appHelp)
 }
 
 // renderHelp returns the rendered help view and associated line height for


### PR DESCRIPTION
- fix: only show edit help on pager when editable
- fix: only allow `LocalDoc`s to be edited
- feat: show e • edit help when document is editable
