### PR TITLE
docs: fix typos

### DIFF
--- a/ui/markdown.go
+++ b/ui/markdown.go
@@ -134,7 +134,7 @@ func (m markdownsByLocalFirst) Less(i, j int) bool {
 		return m[i].CreatedAt.After(m[j].CreatedAt)
 	}
 
-	// If the times also match, sort by unqiue ID.
+	// If the times also match, sort by unique ID.
 	ids := []ksuid.KSUID{m[i].uniqueID, m[j].uniqueID}
 	ksuid.Sort(ids)
 	return ids[0] == m[i].uniqueID

--- a/ui/pager.go
+++ b/ui/pager.go
@@ -96,7 +96,7 @@ var (
 				Background(yellowGreen)
 
 	pagerNoteInputCursorStyle = lipgloss.NewStyle().
-					Foreground(fuschia)
+					Foreground(fuchsia)
 )
 
 type (

--- a/ui/stash.go
+++ b/ui/stash.go
@@ -40,7 +40,7 @@ var (
 
 	logoStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#ECFD65")).
-			Background(fuschia).
+			Background(fuchsia).
 			Bold(true)
 
 	stashSpinnerStyle = lipgloss.NewStyle().
@@ -49,7 +49,7 @@ var (
 				Foreground(yellowGreen).
 				MarginRight(1)
 	stashInputCursorStyle = lipgloss.NewStyle().
-				Foreground(fuschia).
+				Foreground(fuchsia).
 				MarginRight(1)
 )
 

--- a/ui/stashhelp.go
+++ b/ui/stashhelp.go
@@ -15,7 +15,7 @@ type helpEntry struct{ key, val string }
 type helpColumn []helpEntry
 
 // newHelpColumn creates a help column from pairs of string arguments
-// represeting keys and values. If the arguments are not even (and therein
+// representing keys and values. If the arguments are not even (and therein
 // not every key has a matching value) the function will panic.
 func newHelpColumn(pairs ...string) (h helpColumn) {
 	if len(pairs)%2 != 0 {
@@ -193,7 +193,7 @@ func (m stashModel) renderHelp(groups ...[]string) (string, int) {
 }
 
 // Builds the help view from various sections pieces, truncating it if the view
-// would otherwise wrap to two lines. Help view entires should come in as pairs,
+// would otherwise wrap to two lines. Help view entries should come in as pairs,
 // with the first being the key and the second being the help text.
 func (m stashModel) miniHelpView(entries ...string) string {
 	if len(entries) == 0 {

--- a/ui/stashitem.go
+++ b/ui/stashitem.go
@@ -76,7 +76,7 @@ func stashItemView(b *strings.Builder, m stashModel, index int, md *markdown) {
 				icon = dullFuchsiaFg(icon)
 				if m.currentSection().key == filterSection &&
 					m.filterState == filterApplied || singleFilteredItem {
-					s := lipgloss.NewStyle().Foreground(fuschia)
+					s := lipgloss.NewStyle().Foreground(fuchsia)
 					title = styleFilteredText(title, m.filterInput.Value(), s, s.Copy().Underline(true))
 				} else {
 					title = fuchsiaFg(title)

--- a/ui/styles.go
+++ b/ui/styles.go
@@ -18,7 +18,7 @@ var (
 	cream           = AdaptiveColor{Light: "#FFFDF5", Dark: "#FFFDF5"}
 	yellowGreen     = AdaptiveColor{Light: "#04B575", Dark: "#ECFD65"}
 	dullYellowGreen = AdaptiveColor{Light: "#6BCB94", Dark: "#9BA92F"}
-	fuschia         = AdaptiveColor{Light: "#EE6FF8", Dark: "#EE6FF8"}
+	fuchsia         = AdaptiveColor{Light: "#EE6FF8", Dark: "#EE6FF8"}
 	dimFuchsia      = AdaptiveColor{Light: "#F1A8FF", Dark: "#99519E"}
 	dullFuchsia     = AdaptiveColor{Dark: "#AD58B4", Light: "#F793FF"}
 	dimDullFuchsia  = AdaptiveColor{Light: "#F6C9FF", Dark: "#6B3A6F"}
@@ -47,13 +47,13 @@ var (
 	semiDimGreenFg = NewStyle().Foreground(semiDimGreen).Render
 	dimGreenFg     = NewStyle().Foreground(dimGreen).Render
 
-	fuchsiaFg    = NewStyle().Foreground(fuschia).Render
+	fuchsiaFg    = NewStyle().Foreground(fuchsia).Render
 	dimFuchsiaFg = NewStyle().Foreground(dimFuchsia).Render
 
 	dullFuchsiaFg    = NewStyle().Foreground(dullFuchsia).Render
 	dimDullFuchsiaFg = NewStyle().Foreground(dimDullFuchsia).Render
 
-	indigoFg    = NewStyle().Foreground(fuschia).Render
+	indigoFg    = NewStyle().Foreground(fuchsia).Render
 	dimIndigoFg = NewStyle().Foreground(dimIndigo).Render
 
 	subtleIndigoFg    = NewStyle().Foreground(subtleIndigo).Render

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -91,7 +91,7 @@ type (
 	}
 )
 
-// applicationContext indicates the area of the application something appies
+// applicationContext indicates the area of the application something applies
 // to. Occasionally used as an argument to commands and messages.
 type applicationContext int
 
@@ -620,7 +620,7 @@ func generateSSHKeys() tea.Msg {
 		return keygenFailedMsg{err}
 	}
 	if debug {
-		log.Println("keys generated succcessfully")
+		log.Println("keys generated successfully")
 	}
 	return keygenSuccessMsg{}
 }


### PR DESCRIPTION
Found via `typos --format brief`