### PR TITLE
README: add Winget to Windows Install Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ pkg install glow
 # Solus
 eopkg install glow
 
-# Windows (with Scoop or Chocolatey)
-scoop install glow
+# Windows (with Chocolatey or Scoop or Winget)
 choco install glow
+scoop install glow
+winget install charmbracelet.glow
 
 # Android (with termux)
 pkg install glow


### PR DESCRIPTION
## Changes

- Rearrange Windows Install options.
- Add Winget to Windows Install options.

## Description

Recently, I added the [manifest](https://github.com/microsoft/winget-pkgs/tree/master/manifests/c/charmbracelet/glow) for `glow` to Winget. I have highlighted it here with the install command. Once new releases are made, I will update the Winget manifest asap.