### PR TITLE
Replace string concatenation in loop with string builder

### DIFF
--- a/main.go
+++ b/main.go
@@ -284,15 +284,16 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 
 	// trim lines
 	lines := strings.Split(string(out), "\n")
-	var content string
+	var cb strings.Builder
 	for i, s := range lines {
-		content += strings.TrimSpace(s)
+		cb.WriteString(strings.TrimSpace(s))
 
 		// don't add an artificial newline after the last split
 		if i+1 < len(lines) {
-			content += "\n"
+			cb.WriteString("\n")
 		}
 	}
+	content := cb.String()
 
 	// display
 	if pager || cmd.Flags().Changed("pager") {


### PR DESCRIPTION
For large input files, the string concatenation in a hot loop done to trim lines is a bottleneck, running in quadratic time since it has to copy the current string every time. Using a string builder, this can be optimized in linear time.
For Minetest's large [`lua_api.md`](https://github.com/minetest/minetest/blob/master/doc/lua_api.md), this brings the time down from 45s to 3s, a 15x speedup, on my laptop.