### PR TITLE
docs: add snap install in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ choco install glow
 # Android (with termux)
 pkg install glow
 
+# Snap
+sudo snap install glow
+
 # Debian/Ubuntu
 sudo mkdir -p /etc/apt/keyrings
 curl -fsSL https://repo.charm.sh/apt/gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/charm.gpg


### PR DESCRIPTION
## Because
I saw that glow is available to install as a snap package, but that isn't mentioned in the readme.

## Changes
- Added install snap instructions in `README.md`

