### PR TITLE
fix: handle running inside a snap

### DIFF
--- a/config_cmd.go
+++ b/config_cmd.go
@@ -23,13 +23,14 @@ pager: false
 width: 80`
 
 var configCmd = &cobra.Command{
-	Use:     "config",
-	Hidden:  false,
-	Short:   "Edit the glow config file",
-	Long:    paragraph(fmt.Sprintf("\n%s the glow config file. We’ll use EDITOR to determine which editor to use. If the config file doesn't exist, it will be created.", keyword("Edit"))),
-	Example: paragraph("glow config\nglow config --config path/to/config.yml"),
-	Args:    cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	Use:          "config",
+	Hidden:       false,
+	Short:        "Edit the glow config file",
+	Long:         paragraph(fmt.Sprintf("\n%s the glow config file. We’ll use EDITOR to determine which editor to use. If the config file doesn't exist, it will be created.", keyword("Edit"))),
+	Example:      paragraph("glow config\nglow config --config path/to/config.yml"),
+	Args:         cobra.NoArgs,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
 		if configFile == "" {
 			scope := gap.NewScope(gap.User, "glow")
 
@@ -64,7 +65,10 @@ var configCmd = &cobra.Command{
 			return err
 		}
 
-		c := editor.Cmd(configFile)
+		c, err := editor.Cmd(configFile)
+		if err != nil {
+			return fmt.Errorf("could not edit %s: %w", configFile, err)
+		}
 		c.Stdin = os.Stdin
 		c.Stdout = os.Stdout
 		c.Stderr = os.Stderr

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -13,7 +13,7 @@ const defaultEditor = "nano"
 // $EDITOR is set.
 func Cmd(path string) (*exec.Cmd, error) {
 	if os.Getenv("SNAP_REVISION") != "" {
-		return nil, fmt.Errorf("glow is sandboxed, and thus cannot open an editor. To continue using this feature, please install glow using another option")
+		return nil, fmt.Errorf("Did you install with Snap? Glow is sandboxed and unable to open an editor. Please install Glow with Go or another package manager to enable editing.")
 	}
 	editor, args := getEditor()
 	return exec.Command(editor, append(args, path)...), nil

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -1,6 +1,7 @@
 package editor
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -10,9 +11,12 @@ const defaultEditor = "nano"
 
 // Cmd returns a *exec.Cmd editing the given path with $EDITOR or nano if no
 // $EDITOR is set.
-func Cmd(path string) *exec.Cmd {
+func Cmd(path string) (*exec.Cmd, error) {
+	if os.Getenv("SNAP_REVISION") != "" {
+		return nil, fmt.Errorf("glow is sandboxed, and thus cannot open an editor. To continue using this feature, please install glow using another option")
+	}
 	editor, args := getEditor()
-	return exec.Command(editor, append(args, path)...)
+	return exec.Command(editor, append(args, path)...), nil
 }
 
 func getEditor() (string, []string) {

--- a/editor/editor_test.go
+++ b/editor/editor_test.go
@@ -16,11 +16,22 @@ func TestEditor(t *testing.T) {
 	} {
 		t.Run(k, func(t *testing.T) {
 			t.Setenv("EDITOR", k)
-			cmd := Cmd("README.md")
+			cmd, _ := Cmd("README.md")
 			got := cmd.Args
 			if !reflect.DeepEqual(got, v) {
 				t.Fatalf("expected %v; got %v", v, got)
 			}
 		})
 	}
+
+	t.Run("inside snap", func(t *testing.T) {
+		t.Setenv("SNAP_REVISION", "10")
+		got, err := Cmd("foo")
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+		if got != nil {
+			t.Fatalf("should have returned nil, got %v", got)
+		}
+	})
 }

--- a/ui/editor.go
+++ b/ui/editor.go
@@ -11,5 +11,12 @@ func openEditor(path string) tea.Cmd {
 	cb := func(err error) tea.Msg {
 		return editorFinishedMsg{err}
 	}
-	return tea.ExecProcess(editor.Cmd(path), cb)
+
+	editor, err := editor.Cmd(path)
+	if err != nil {
+		return func() tea.Msg {
+			return errMsg{err}
+		}
+	}
+	return tea.ExecProcess(editor, cb)
 }


### PR DESCRIPTION
snaps have a myriad of `SNAP_.*` env vars set, so I see if one of them is present (in which case we are sandboxed, and can't really open an EDITOR) and error out to the user suggesting installing it some other way.