### PR TITLE
feat(readme.md): adds `emerge` package in GURU

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Glow
+app-misc/glowapp-misc/glowapp-misc/glow# Glow
 
 Render markdown on the CLI, with _pizzazz_!
 
@@ -43,6 +43,9 @@ pacman -S glow
 
 # Void Linux
 xbps-install -S glow
+
+# Gentoo Linux (with GURU overlay)
+emerge --ask app-misc/glow
 
 # Nix
 nix-env -iA nixpkgs.glow


### PR DESCRIPTION
Title says it all.

```sh
root # emerge -s glow
```
returns
```
*  app-misc/glow
      Latest version available: 1.5.1
      Latest version installed: 1.5.1
      Size of files: 172855 KiB
      Homepage:      https://github.com/charmbracelet/glow
      Description:   Render markdown on the CLI, with pizzazz!
      License:       Apache-2.0 BSD-2 BSD MIT MPL-2.0
```