### PR TITLE
Add an environment variable to control the config path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,12 @@ to find more styles. Or [make your own](https://github.com/charmbracelet/glamour
 If you find yourself supplying the same flags to `glow` all the time, it's
 probably a good idea to create a config file. Run `glow config`, which will open
 it in your favorite $EDITOR. Alternatively you can manually put a file named
-`glow.yml` in the default config path of you platform. If you're not sure where
+`glow.yml` in the default config path of your platform. If you're not sure where
 that is, please refer to `glow --help`.
+
+Alternatively, you can set the config path yourself by adding the
+$GLOW_CONFIG_HOME variable to your environment, for example
+```export GLOW_CONFIG_HOME "$HOME/.config/glow"```
 
 Here's an example config:
 

--- a/main.go
+++ b/main.go
@@ -399,11 +399,20 @@ func initConfig() {
 	if configFile != "" {
 		viper.SetConfigFile(configFile)
 	} else {
-		scope := gap.NewScope(gap.User, "glow")
-		dirs, err := scope.ConfigDirs()
-		if err != nil {
-			fmt.Println("Can't retrieve default config. Please manually pass a config file with '--config'")
-			os.Exit(1)
+		var dirs []string
+		var err error
+
+		envConfigDir, envDirExists := os.LookupEnv("GLOW_CONFIG_HOME")
+
+		if !envDirExists {
+			scope := gap.NewScope(gap.User, "glow")
+			dirs, err = scope.ConfigDirs()
+			if err != nil {
+				fmt.Println("Can't retrieve default config. Please manually pass a config file with '--config'")
+				os.Exit(1)
+			}
+		} else {
+			dirs = append(dirs, envConfigDir)
 		}
 
 		for _, v := range dirs {


### PR DESCRIPTION
Not everyone wants to use Mac OS's default config path "~/Library/Preferences/" as returned by [go-paths](https://github.com/muesli/go-app-paths?tab=readme-ov-file#directories).

This patch includes the environment variable ```GLOW_CONFIG_HOME``` to set, so Mac OS users don't have to run ```glow --config ~/.config/glow/glow.yml``` or something like that.
If you set the config variable, it is used, if not, the original flow is used.

Oh, and a small spelling error fix.
