### PR TITLE
Add reload mode

### DIFF
--- a/glow_test.go
+++ b/glow_test.go
@@ -15,8 +15,7 @@ func TestGlowSources(t *testing.T) {
 
 	for _, v := range tt {
 		buf := &bytes.Buffer{}
-		err := executeArg(rootCmd, v, buf)
-
+		_, err := executeArg(rootCmd, v, buf)
 		if err != nil {
 			t.Errorf("Error during execution (args: %s): %v", v, err)
 		}
@@ -35,6 +34,12 @@ func TestGlowFlags(t *testing.T) {
 			args: []string{"-p"},
 			check: func() bool {
 				return pager
+			},
+		},
+		{
+			args: []string{"-r"},
+			check: func() bool {
+				return reload
 			},
 		},
 		{


### PR DESCRIPTION
Fixes #560
Passing the -r --reload flag enables the reload mode.
This is available only when using a pager (with flag -p) and when opening one file only. 
Named it reload mode instead of watch mode because the -w flag was already taken.