### PR TITLE
docs: use nix-shell as nix-env -iA is bad practice on NixOS/Darwin

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ pacman -S glow
 # Void Linux
 xbps-install -S glow
 
-# Nix
-nix-env -iA nixpkgs.glow
+# Nix shell
+nix-shell -p glow --command glow
 
 # FreeBSD
 pkg install glow


### PR DESCRIPTION
Hi there,
just found this very cool project. 

As nix-env -iA is bad practice (very hard to uninstall) I changed it to nix-shell which is the default if you want to try out new software.
On NixOS / Darwin with nix config you will add it to your configuration file eventually.
The old way would explain how to install it using nix on non nixos permanently.
Adding both (the old and the new one) would also be an option. 
Just tell me I will fix it.

Thanks for this great software :)