### PR TITLE
fix: pass color profile down to glamour

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/glow/ui"
 	"github.com/charmbracelet/glow/utils"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/log"
 	gap "github.com/muesli/go-app-paths"
 	"github.com/spf13/cobra"
@@ -271,6 +272,7 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 
 	// initialize glamour
 	r, err := glamour.NewTermRenderer(
+		glamour.WithColorProfile(lipgloss.ColorProfile()),
 		utils.GlamourStyle(style, isCode),
 		glamour.WithWordWrap(int(width)),
 		glamour.WithBaseURL(baseURL),


### PR DESCRIPTION
glamour was ignoring the detected color profile when running `glow file.md`