### PR TITLE
Enable "r" in filter state

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -187,7 +187,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Batch(batch...)
 			}
 		case "r":
+			var cmd tea.Cmd
 			if m.state == stateShowStash {
+				// pass through all keys if we're editing the filter
+				if m.stash.filterState == filtering {
+					m.stash, cmd = m.stash.update(msg)
+					return m, cmd
+				}
 				m.stash.markdowns = nil
 				return m, m.Init()
 			}


### PR DESCRIPTION
Fixes #644 

First of all, thank you for this tool! Great fun to use. I was a bit annoyed by it triggering a reload when I'm inputting a filter. To fix it I just copied the way in which this was done from the `q` key. If you want it done differently or have another fix in the works, let me know!