### PR TITLE
fix: remove more stash-related stuff

### DIFF
--- a/ui/stash.go
+++ b/ui/stash.go
@@ -141,7 +141,6 @@ type stashModel struct {
 	err                error
 	spinner            spinner.Model
 	filterInput        textinput.Model
-	stashFullyLoaded   bool // have we loaded all available stashed documents from the server?
 	viewState          stashViewState
 	filterState        filterState
 	showFullHelp       bool
@@ -726,10 +725,6 @@ func (m stashModel) view() string {
 				p.Type = paginator.Arabic
 				pagination = paginationStyle.Render(p.View())
 			}
-
-			// We could also look at m.stashFullyLoaded and add an indicator
-			// showing that we don't actually know how many more pages there
-			// are.
 		}
 
 		s += fmt.Sprintf(

--- a/ui/stashhelp.go
+++ b/ui/stashhelp.go
@@ -130,9 +130,6 @@ func (m stashModel) helpView() (string, int) {
 		filterHelp = []string{"/", "edit search", "esc", "clear filter"}
 	} else {
 		filterHelp = []string{"/", "find"}
-		if m.stashFullyLoaded {
-			filterHelp = append(filterHelp, "t", "team filter")
-		}
 	}
 
 	if isEditable {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -7,11 +7,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour/styles"
 	"github.com/charmbracelet/glow/v2/utils"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/log"
 	"github.com/muesli/gitcha"
 	te "github.com/muesli/termenv"
@@ -141,14 +139,6 @@ func newModel(cfg Config) tea.Model {
 			cfg.GlamourStyle = styles.LightStyle
 		}
 	}
-
-	teamList := list.New([]list.Item{}, list.NewDefaultDelegate(), 0, 0)
-	teamList.Styles.Title = lipgloss.NewStyle().Foreground(yellowGreen)
-	teamList.SetStatusBarItemName("team", "teams")
-	teamList.SetShowHelp(true)
-
-	// We use the team list status message as a permanent placeholder.
-	teamList.StatusMessageLifetime = time.Hour
 
 	common := commonModel{
 		cfg: cfg,


### PR DESCRIPTION
Removing some more artifacts of the remote stash feature that were left behind.

On a side note: eventually, we should probably rename 'stash' to something else internally, as of now the old name is still being used.