### PR TITLE
fix: allow for typing the letter r into filter

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -178,6 +178,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case "r":
 			if m.state == stateShowStash {
+
+				if m.stash.filterState == filtering {
+					var cmd tea.Cmd
+
+					m.stash, cmd = m.stash.update(msg)
+					return m, cmd
+				}
+
 				m.stash.markdowns = nil
 				return m, m.Init()
 			}


### PR DESCRIPTION
Fix for the [bug reported in this issue](https://github.com/charmbracelet/glow/issues/659), where you would be unable to type the letter 'r' when in filter mode.