### PR TITLE
fix: restore hint for `e` / `edit` on the footer

### DIFF
--- a/ui/stashhelp.go
+++ b/ui/stashhelp.go
@@ -100,7 +100,6 @@ func (m stashModel) helpView() (string, int) {
 	}
 
 	var (
-		isEditable    bool
 		navHelp       []string
 		filterHelp    []string
 		selectionHelp []string
@@ -132,16 +131,13 @@ func (m stashModel) helpView() (string, int) {
 		filterHelp = []string{"/", "find"}
 	}
 
-	if isEditable {
-		editHelp = []string{"e", "edit"}
-	}
-
 	// If there are errors
 	if m.err != nil {
 		appHelp = append(appHelp, "!", "errors")
 	}
 
 	appHelp = append(appHelp, "r", "refresh")
+	appHelp = append(appHelp, "e", "edit")
 	appHelp = append(appHelp, "q", "quit")
 
 	// Detailed help


### PR DESCRIPTION
I found this while working on an unrelated issue. There was not hint for `e`/ `edit` at all.

### Before

<img width="563" alt="Screenshot 2025-02-03 at 17 56 47" src="https://github.com/user-attachments/assets/9b95ad33-01bf-4466-ba04-b00adff83112" />

### After

<img width="563" alt="Screenshot 2025-02-03 at 17 57 00" src="https://github.com/user-attachments/assets/efc99a5b-d770-483b-80b4-28d8799afe33" />
