### PR TITLE
feat: add new `--tui` / `-t` flag

### DIFF
--- a/ui/config.go
+++ b/ui/config.go
@@ -11,8 +11,8 @@ type Config struct {
 	EnableMouse      bool
 	PreserveNewLines bool
 
-	// Which directory should we start from?
-	WorkingDirectory string
+	// Working directory or file path
+	Path string
 
 	// For debugging the UI
 	HighPerformancePager bool `env:"GLOW_HIGH_PERFORMANCE_PAGER" envDefault:"true"`


### PR DESCRIPTION
We had two possible paths to address this:

- Add a new `--tui` / `-t` flag
- Add a new `--mode` flag with `pager`/`tui`/`none` as possible values

Having a `--tui` flag felt a bit more reasonable to me because:

- The `-m` shortant is already taken by `--mouse` while `-t` is available. (We could of course use `-M` though).
- This avoids the need to deprecate `--pager` / `-p`.

Happy to change if you find better, though.

Let me know if you find any bugs while testing.

---

This will close the following issues:

- https://github.com/charmbracelet/glow/issues/129
- https://github.com/charmbracelet/glow/issues/489
- https://github.com/charmbracelet/glow/issues/535
- https://github.com/charmbracelet/glow/pull/548

