### PR TITLE
fix: correct path strip

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -421,8 +421,9 @@ func localFileToMarkdown(cwd string, res gitcha.SearchResult) *markdown {
 }
 
 func stripAbsolutePath(fullPath, cwd string) string {
-	path, _ := filepath.Rel(cwd, fullPath)
-	return path
+	fp, _ := filepath.EvalSymlinks(fullPath)
+	cp, _ := filepath.EvalSymlinks(cwd)
+	return strings.ReplaceAll(fp, cp+string(os.PathSeparator), "")
 }
 
 // Lightweight version of reflow's indent function.


### PR DESCRIPTION
* last PR changed 'strings.ReplaceAll' to 'filepath.Rel'
* but still did not handle (or think about) symlink well