### PR TITLE
fix: disallow 'h' key when was pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,4 +22,4 @@ jobs:
   ruleguard:
     uses: charmbracelet/meta/.github/workflows/ruleguard.yml@main
     with:
-      go-version: stable
+      go-version: 1.23.6

--- a/main.go
+++ b/main.go
@@ -201,21 +201,10 @@ func validateOptions(cmd *cobra.Command) error {
 	return nil
 }
 
-func stdinIsPipe() (bool, error) {
-	stat, err := os.Stdin.Stat()
-	if err != nil {
-		return false, err
-	}
-	if stat.Mode()&os.ModeCharDevice == 0 || stat.Size() > 0 {
-		return true, nil
-	}
-	return false, nil
-}
-
 func execute(cmd *cobra.Command, args []string) error {
 	// if stdin is a pipe then use stdin for input. note that you can also
 	// explicitly use a - to read from stdin.
-	if yes, err := stdinIsPipe(); err != nil {
+	if yes, err := utils.StdinIsPipe(); err != nil {
 		return err
 	} else if yes {
 		src := &source{reader: os.Stdin}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -246,8 +246,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 
 		case "left", "h", "delete":
-			yes, _ := utils.StdinIsPipe()
-			if m.state == stateShowDocument && !yes {
+			isPipe, _ := utils.StdinIsPipe()
+			path := m.common.cfg.Path
+			if path == "" {
+				path = "."
+			}
+			isDir := false
+			info, err := os.Stat(path)
+			if err == nil && info.IsDir() {
+				isDir = true
+			}
+			if m.state == stateShowDocument && !isPipe && isDir {
 				cmds = append(cmds, m.unloadDocument()...)
 				return m, tea.Batch(cmds...)
 			}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -246,7 +246,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 
 		case "left", "h", "delete":
-			if m.state == stateShowDocument {
+			yes, _ := utils.StdinIsPipe()
+			if m.state == stateShowDocument && !yes {
 				cmds = append(cmds, m.unloadDocument()...)
 				return m, tea.Batch(cmds...)
 			}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -110,3 +110,14 @@ func GlamourStyle(style string, isCode bool) glamour.TermRendererOption {
 
 	return glamour.WithStyles(styleConfig)
 }
+
+func StdinIsPipe() (bool, error) {
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return false, err
+	}
+	if stat.Mode()&os.ModeCharDevice == 0 || stat.Size() > 0 {
+		return true, nil
+	}
+	return false, nil
+}


### PR DESCRIPTION
* 1. if pager was 'less' then 'h' was its native 'help'
* 2. if pager was 'tui' then seems no sense 'h' to back