### PR TITLE
fix glow_style and glamour_style usage

### DIFF
--- a/main.go
+++ b/main.go
@@ -307,10 +307,7 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 	// display
 	switch {
 	case pager || cmd.Flags().Changed("pager"):
-		pagerCmd := os.Getenv("PAGER")
-		if pagerCmd == "" {
-			pagerCmd = "less -r"
-		}
+		pagerCmd := utils.Getenv("PAGER", "less -r")
 
 		pa := strings.Split(pagerCmd, " ")
 		c := exec.Command(pa[0], pa[1:]...) // nolint:gosec
@@ -332,15 +329,11 @@ func runTUI(path string, content string) error {
 		return fmt.Errorf("error parsing config: %v", err)
 	}
 
-	// use style set in env, or auto if unset
-	if err := validateStyle(cfg.GlamourStyle); err != nil {
-		cfg.GlamourStyle = style
-	}
-
 	cfg.Path = path
 	cfg.ShowAllFiles = showAllFiles
 	cfg.ShowLineNumbers = showLineNumbers
 	cfg.GlamourMaxWidth = width
+	cfg.GlamourStyle = style
 	cfg.EnableMouse = mouse
 	cfg.PreserveNewLines = preserveNewLines
 
@@ -400,7 +393,7 @@ func init() {
 	_ = viper.BindPFlag("showLineNumbers", rootCmd.Flags().Lookup("line-numbers"))
 	_ = viper.BindPFlag("all", rootCmd.Flags().Lookup("all"))
 
-	viper.SetDefault("style", styles.AutoStyle)
+	viper.SetDefault("style", utils.Getenv("GLAMOUR_STYLE", styles.AutoStyle))
 	viper.SetDefault("width", 0)
 	viper.SetDefault("all", true)
 

--- a/ui/config.go
+++ b/ui/config.go
@@ -7,7 +7,7 @@ type Config struct {
 	Gopath           string `env:"GOPATH"`
 	HomeDir          string `env:"HOME"`
 	GlamourMaxWidth  uint
-	GlamourStyle     string `env:"GLAMOUR_STYLE"`
+	GlamourStyle     string
 	EnableMouse      bool
 	PreserveNewLines bool
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -39,6 +39,15 @@ func ExpandPath(path string) string {
 	return os.ExpandEnv(path)
 }
 
+// Getenv retrieves the value of the environment variable named by the key.
+// It returns the value, or fallback value if the variable is not present.
+func Getenv(key string, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
 // WrapCodeBlock wraps a string in a code block with the given language.
 func WrapCodeBlock(s, language string) string {
 	return "```" + language + "\n" + s + "```"


### PR DESCRIPTION
Resolves https://github.com/charmbracelet/glow/issues/673
See also https://github.com/charmbracelet/glow/pull/587#issuecomment-2375194443

Use `GLAMOUR_STYLE` value as default style with fallback to `styles.AutoStyle`

Consider `GLAMOUR_STYLE` and `GLOW_STYLE` as interchangeable, if both present - `GLOW_STYLE` would be prioritized.