### PR TITLE
fix: watch for write+create changes on file parent

### DIFF
--- a/ui/pager.go
+++ b/ui/pager.go
@@ -476,14 +476,14 @@ func (m *pagerModel) initWatcher() {
 }
 
 func (m *pagerModel) watchFile() tea.Msg {
-	pathDir := filepath.Dir(m.currentDocument.localPath)
+	dir := m.localDir()
 
-	if err := m.watcher.Add(pathDir); err != nil {
-		log.Error("error adding file to fsnotify watcher", "error", err)
+	if err := m.watcher.Add(dir); err != nil {
+		log.Error("error adding dir to fsnotify watcher", "error", err)
 		return nil
 	}
 
-	log.Info("fsnotify watching file", "file", pathDir)
+	log.Info("fsnotify watching dir", "dir", dir)
 
 	for {
 		select {
@@ -502,18 +502,22 @@ func (m *pagerModel) watchFile() tea.Msg {
 			if !ok {
 				continue
 			}
-			log.Debug("fsnotify error", "file", pathDir, "error", err)
+			log.Debug("fsnotify error", "dir", dir, "error", err)
 		}
 	}
 }
 
 func (m *pagerModel) unwatchFile() {
-	pathDir := filepath.Dir(m.currentDocument.localPath)
+	dir := m.localDir()
 
-	err := m.watcher.Remove(pathDir)
+	err := m.watcher.Remove(dir)
 	if err == nil {
-		log.Debug("fsnotify file unwatched", "file", pathDir)
+		log.Debug("fsnotify dir unwatched", "dir", dir)
 	} else {
-		log.Error("fsnotify fail to unwatch file", "file", pathDir, "error", err)
+		log.Error("fsnotify fail to unwatch dir", "dir", dir, "error", err)
 	}
+}
+
+func (m *pagerModel) localDir() string {
+	return filepath.Dir(m.currentDocument.localPath)
 }

--- a/ui/pager.go
+++ b/ui/pager.go
@@ -3,7 +3,6 @@ package ui
 import (
 	"fmt"
 	"math"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -477,44 +476,44 @@ func (m *pagerModel) initWatcher() {
 }
 
 func (m *pagerModel) watchFile() tea.Msg {
-	path := m.relFilePath()
+	pathDir := filepath.Dir(m.currentDocument.localPath)
 
-	if err := m.watcher.Add(path); err != nil {
+	if err := m.watcher.Add(pathDir); err != nil {
 		log.Error("error adding file to fsnotify watcher", "error", err)
 		return nil
 	}
 
-	log.Info("fsnotify watching file", "file", path)
+	log.Info("fsnotify watching file", "file", pathDir)
 
 	for {
 		select {
 		case event, ok := <-m.watcher.Events:
-			if !ok || !event.Has(fsnotify.Write) {
+			if !ok || event.Name != m.currentDocument.localPath {
 				continue
 			}
-			log.Debug("fsnotify event", "file", path, "event", event.Op)
+
+			if !event.Has(fsnotify.Write) && !event.Has(fsnotify.Create) {
+				continue
+			}
+
+			log.Debug("fsnotify event", "file", event.Name, "event", event.Op)
 			return reloadMsg{}
 		case err, ok := <-m.watcher.Errors:
 			if !ok {
 				continue
 			}
-			log.Debug("fsnotify error", "file", path, "error", err)
+			log.Debug("fsnotify error", "file", pathDir, "error", err)
 		}
 	}
 }
 
 func (m *pagerModel) unwatchFile() {
-	path := m.relFilePath()
+	pathDir := filepath.Dir(m.currentDocument.localPath)
 
-	err := m.watcher.Remove(path)
+	err := m.watcher.Remove(pathDir)
 	if err == nil {
-		log.Debug("fsnotify file unwatched", "file", path)
+		log.Debug("fsnotify file unwatched", "file", pathDir)
 	} else {
-		log.Error("fsnotify fail to unwatch file", "file", path, "error", err)
+		log.Error("fsnotify fail to unwatch file", "file", pathDir, "error", err)
 	}
-}
-
-func (m *pagerModel) relFilePath() string {
-	wd, _ := os.Getwd()
-	return stripAbsolutePath(m.currentDocument.localPath, wd)
 }


### PR DESCRIPTION
Closes #733 

Follows the guidelines in https://github.com/fsnotify/fsnotify?tab=readme-ov-file#watching-a-file-doesnt-work-well to watch the files parent directory instead of the file itself.

Tested on both mac and Linux (Arch). On mac it seems like only the CREATE event will come through followed by a few others. On Linux it will be a CREATE followed by a WRITE. In both cases watching the parent directory makes sure any CREATE events don't have an impact on the watched file.

Might end up with more frequent reloads but I haven't dug into it that much.