### PR TITLE
fix: TUI mode handling of remote URLs

### DIFF
--- a/main.go
+++ b/main.go
@@ -327,7 +327,13 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 		}
 		return nil
 	case tui || cmd.Flags().Changed("tui"):
-		return runTUI(src.URL, content)
+		path := ""
+		if _, err := url.ParseRequestURI(src.URL); err != nil || !strings.Contains(src.URL, "://") {
+			// It's a local file, so we can pass the path
+			path = src.URL
+		}
+		// Always pass the content, which we've already loaded
+		return runTUI(path, content)
 	default:
 		if _, err = fmt.Fprint(w, out); err != nil {
 			return fmt.Errorf("unable to write to writer: %w", err)

--- a/main.go
+++ b/main.go
@@ -328,11 +328,9 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 		return nil
 	case tui || cmd.Flags().Changed("tui"):
 		path := ""
-		if _, err := url.ParseRequestURI(src.URL); err != nil || !strings.Contains(src.URL, "://") {
-			// It's a local file, so we can pass the path
+		if !isURL(src.URL) {
 			path = src.URL
 		}
-		// Always pass the content, which we've already loaded
 		return runTUI(path, content)
 	default:
 		if _, err = fmt.Fprint(w, out); err != nil {

--- a/url.go
+++ b/url.go
@@ -79,3 +79,8 @@ func gitlabReadmeURL(path string) *url.URL {
 	u, _ := url.Parse(gitlabURL.String())
 	return u.JoinPath(path)
 }
+
+func isURL(path string) bool {
+	_, err := url.ParseRequestURI(path)
+	return err == nil && strings.Contains(path, "://")
+}


### PR DESCRIPTION
When using the -t flag with a remote URL, Glow was trying to treat the URL as a local file path. 
This change fixes the issue by only passing the path parameter to the TUI when dealing with local files, and passing just the content for remote URLs. 

Fixes #719 

## Tested with:

- Remote raw URLs: `glow -t https://raw.githubusercontent.com/charmbracelet/glow/refs/heads/master/README.md`
- GitHub repository URLs: `glow -t https://github.com/charmbracelet/glow`
- GitLab repository URLS: `glow -t https://gitlab.com/interception/linux/plugins/caps2esc`
- Local markdown files: `glow -t README.md`