### PR TITLE
fix: sync viewport on half page up/down to prevent duplicate strings

### DIFF
--- a/ui/pager.go
+++ b/ui/pager.go
@@ -204,6 +204,18 @@ func (m pagerModel) update(msg tea.Msg) (pagerModel, tea.Cmd) {
 				cmds = append(cmds, viewport.Sync(m.viewport))
 			}
 
+		case "d":
+			m.viewport.HalfViewDown()
+			if m.viewport.HighPerformanceRendering {
+				cmds = append(cmds, viewport.Sync(m.viewport))
+			}
+
+		case "u":
+			m.viewport.HalfViewUp()
+			if m.viewport.HighPerformanceRendering {
+				cmds = append(cmds, viewport.Sync(m.viewport))
+			}
+
 		case "e":
 			lineno := int(math.RoundToEven(float64(m.viewport.TotalLineCount()) * m.viewport.ScrollPercent()))
 			if m.viewport.AtTop() {


### PR DESCRIPTION
### Describe your changes

Refreshes the `viewport` on `HalfViewDown`/`HalfViewUp` similar to `GoToTop` and `GoToBottom`.

I was able to replicate the linked issue and confirms this fixes it (for me at least).

This is the text I used to replicate the issue

```md
Hello World

Hello World

Hello World

Hello World

Hello World

Hello World

Here is

some example

text.

To help

illustrate

my issue.

These

Lines

*Adding a code block*
```C
int main() {
  int x = 0;
  return 0;
}
```end

Might

Be

Duplicated
```

Output of `kitty +kitten query_terminal` that I tested with

```
name: kitty
version: 0.41.1
allow_hyperlinks: yes
font_family: IosevkaNFM
bold_font: IosevkaNFM-SemiBold
italic_font: IosevkaNFM-Italic
bold_italic_font: IosevkaNFM-SemiBoldItalic
font_size: 16
dpi_x: 192
dpi_y: 192
foreground: #f8f8f2
background: #272822
background_opacity: 1
clipboard_control: write-clipboard write-primary read-clipboard-ask read-primary-ask
os_name: linux
```

TUI mode after `d` key before change
![image](https://github.com/user-attachments/assets/9019ada2-3ba7-4f9a-8622-8cf893b83eba)

TUI mode after `d` key after change
![image](https://github.com/user-attachments/assets/e50c5329-9a7b-42d6-96e5-6ad34bce05f1)

### Related issue/discussion: https://github.com/charmbracelet/glow/issues/751

### Checklist before requesting a review

- [x] I have read `CONTRIBUTING.md`
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
