### PR TITLE
Add the ability to sort by date or title

### DIFF
--- a/ui/sort.go
+++ b/ui/sort.go
@@ -13,8 +13,8 @@ const (
 	descending sortOrder = false
 )
 
-func sortMarkdowns(mds []*markdown, byDate bool, ascending sortOrder) {
-	if byDate {
+func sortMarkdowns(mds []*markdown, sortByDate bool, ascending sortOrder) {
+	if sortByDate {
 		if ascending {
 			slices.SortStableFunc(mds, func(a, b *markdown) int {
 				return compareTime(a.Modtime, b.Modtime)

--- a/ui/sort.go
+++ b/ui/sort.go
@@ -3,10 +3,71 @@ package ui
 import (
 	"cmp"
 	"slices"
+	"time"
 )
 
-func sortMarkdowns(mds []*markdown) {
+type SortType int
+type SortOrder int
+
+const (
+	SortByNote SortType = iota
+	SortByDate
+	SortByTitle
+)
+
+const (
+	SortAscending SortOrder = iota
+	SortDescending
+)
+
+type SortState struct {
+	Type  SortType
+	Order SortOrder
+}
+
+func (s *SortState) Toggle(newType SortType) {
+	if s.Type == newType {
+		// Toggle order if same type
+		if s.Order == SortAscending {
+			s.Order = SortDescending
+		} else {
+			s.Order = SortAscending
+		}
+	} else {
+		// Set new type with default ascending order
+		s.Type = newType
+		s.Order = SortAscending
+	}
+}
+
+func sortMarkdowns(mds []*markdown, state SortState) {
 	slices.SortStableFunc(mds, func(a, b *markdown) int {
-		return cmp.Compare(a.Note, b.Note)
+		var comparison int
+
+		switch state.Type {
+		case SortByDate:
+			comparison = compareTime(a.Modtime, b.Modtime)
+		case SortByTitle:
+			comparison = cmp.Compare(a.Note, b.Note)
+		default: // SortByNote
+			comparison = cmp.Compare(a.Note, b.Note)
+		}
+
+		if state.Order == SortDescending {
+			comparison = -comparison
+		}
+
+		return comparison
 	})
+}
+
+func compareTime(a, b time.Time) int {
+	switch {
+	case a.Before(b):
+		return -1
+	case a.After(b):
+		return 1
+	default:
+		return 0
+	}
 }

--- a/ui/stash.go
+++ b/ui/stash.go
@@ -390,8 +390,8 @@ func newStashModel(common *commonModel) stashModel {
 		filterInput:   si,
 		serverPage:    1,
 		sections:      s,
-		sortAscending: true,  // Initialize with sortAscending sort
-		sortByDate:    false, // Initialize with title sort
+		sortAscending: true,
+		sortByDate:    false,
 	}
 
 	return m

--- a/ui/stash.go
+++ b/ui/stash.go
@@ -559,7 +559,7 @@ func (m *stashModel) handleDocumentBrowsing(msg tea.Msg) tea.Cmd {
 				return nil
 			}
 
-		case "d":
+		case "y":
 			m.sortState.Toggle(SortByDate)
 			sortMarkdowns(m.filteredMarkdowns, m.sortState)
 			m.statusMessage = statusMessage{
@@ -607,7 +607,7 @@ func (m *stashModel) handleDocumentBrowsing(msg tea.Msg) tea.Cmd {
 		switch key.String() {
 		case "b", "u":
 			m.paginator().PrevPage()
-		case "f":
+		case "d", "f":
 			m.paginator().NextPage()
 		}
 	}

--- a/ui/stash.go
+++ b/ui/stash.go
@@ -147,7 +147,7 @@ type stashModel struct {
 	showStatusMessage  bool
 	statusMessage      statusMessage
 	statusMessageTimer *time.Timer
-	byDate             bool
+	sortByDate         bool
 	sortAscending      bool
 
 	// Available document sections we can cycle through. We use a slice, rather
@@ -222,7 +222,7 @@ func (m *stashModel) resetFiltering() {
 	m.filterInput.Reset()
 	m.filteredMarkdowns = nil
 
-	sortMarkdowns(m.markdowns, m.byDate, sortOrder(m.sortAscending))
+	sortMarkdowns(m.markdowns, m.sortByDate, sortOrder(m.sortAscending))
 
 	// If the filtered section is present (it's always at the end) slice it out
 	// of the sections slice to remove it from the UI.
@@ -297,7 +297,7 @@ func (m stashModel) selectedMarkdown() *markdown {
 func (m *stashModel) addMarkdowns(mds ...*markdown) {
 	m.markdowns = append(m.markdowns, mds...)
 	m.filteredMarkdowns = m.markdowns
-	sortMarkdowns(m.filteredMarkdowns, m.byDate, sortOrder(m.sortAscending))
+	sortMarkdowns(m.filteredMarkdowns, m.sortByDate, sortOrder(m.sortAscending))
 	m.updatePagination()
 }
 
@@ -391,7 +391,7 @@ func newStashModel(common *commonModel) stashModel {
 		serverPage:    1,
 		sections:      s,
 		sortAscending: true,  // Initialize with sortAscending sort
-		byDate:        false, // Initialize with title sort
+		sortByDate:    false, // Initialize with title sort
 	}
 
 	return m
@@ -562,9 +562,9 @@ func (m *stashModel) handleDocumentBrowsing(msg tea.Msg) tea.Cmd {
 			}
 
 		case "y":
-			m.byDate = true
+			m.sortByDate = true
 			m.sortAscending = !m.sortAscending
-			sortMarkdowns(m.filteredMarkdowns, m.byDate, sortOrder(m.sortAscending))
+			sortMarkdowns(m.filteredMarkdowns, m.sortByDate, sortOrder(m.sortAscending))
 			m.statusMessage = statusMessage{
 				status: normalStatusMessage,
 				message: fmt.Sprintf("Sorted by date %s",
@@ -580,9 +580,9 @@ func (m *stashModel) handleDocumentBrowsing(msg tea.Msg) tea.Cmd {
 			})
 
 		case "t":
-			m.byDate = false
+			m.sortByDate = false
 			m.sortAscending = !m.sortAscending
-			sortMarkdowns(m.filteredMarkdowns, m.byDate, sortOrder(m.sortAscending))
+			sortMarkdowns(m.filteredMarkdowns, m.sortByDate, sortOrder(m.sortAscending))
 			m.statusMessage = statusMessage{
 				status: normalStatusMessage,
 				message: fmt.Sprintf("Sorted by title %s",
@@ -897,7 +897,7 @@ func filterMarkdowns(m stashModel) tea.Cmd {
 	return func() tea.Msg {
 		if m.filterInput.Value() == "" {
 			m.filteredMarkdowns = m.markdowns
-			sortMarkdowns(m.filteredMarkdowns, m.byDate, sortOrder(m.sortAscending))
+			sortMarkdowns(m.filteredMarkdowns, m.sortByDate, sortOrder(m.sortAscending))
 			return filteredMarkdownMsg(m.filteredMarkdowns)
 		}
 

--- a/ui/stash.go
+++ b/ui/stash.go
@@ -147,8 +147,8 @@ type stashModel struct {
 	showStatusMessage  bool
 	statusMessage      statusMessage
 	statusMessageTimer *time.Timer
-	byDate             bool // whether sorting by date
-	ascending          bool // whether sorting ascending
+	byDate             bool
+	sortAscending      bool
 
 	// Available document sections we can cycle through. We use a slice, rather
 	// than a map, because order is important.
@@ -222,7 +222,7 @@ func (m *stashModel) resetFiltering() {
 	m.filterInput.Reset()
 	m.filteredMarkdowns = nil
 
-	sortMarkdowns(m.markdowns, m.byDate, sortOrder(m.ascending))
+	sortMarkdowns(m.markdowns, m.byDate, sortOrder(m.sortAscending))
 
 	// If the filtered section is present (it's always at the end) slice it out
 	// of the sections slice to remove it from the UI.
@@ -297,7 +297,7 @@ func (m stashModel) selectedMarkdown() *markdown {
 func (m *stashModel) addMarkdowns(mds ...*markdown) {
 	m.markdowns = append(m.markdowns, mds...)
 	m.filteredMarkdowns = m.markdowns
-	sortMarkdowns(m.filteredMarkdowns, m.byDate, sortOrder(m.ascending))
+	sortMarkdowns(m.filteredMarkdowns, m.byDate, sortOrder(m.sortAscending))
 	m.updatePagination()
 }
 
@@ -385,13 +385,13 @@ func newStashModel(common *commonModel) stashModel {
 	}
 
 	m := stashModel{
-		common:      common,
-		spinner:     sp,
-		filterInput: si,
-		serverPage:  1,
-		sections:    s,
-		ascending:   true,  // Initialize with ascending sort
-		byDate:      false, // Initialize with title sort
+		common:        common,
+		spinner:       sp,
+		filterInput:   si,
+		serverPage:    1,
+		sections:      s,
+		sortAscending: true,  // Initialize with sortAscending sort
+		byDate:        false, // Initialize with title sort
 	}
 
 	return m
@@ -563,15 +563,15 @@ func (m *stashModel) handleDocumentBrowsing(msg tea.Msg) tea.Cmd {
 
 		case "y":
 			m.byDate = true
-			m.ascending = !m.ascending
-			sortMarkdowns(m.filteredMarkdowns, m.byDate, sortOrder(m.ascending))
+			m.sortAscending = !m.sortAscending
+			sortMarkdowns(m.filteredMarkdowns, m.byDate, sortOrder(m.sortAscending))
 			m.statusMessage = statusMessage{
 				status: normalStatusMessage,
 				message: fmt.Sprintf("Sorted by date %s",
 					map[bool]string{
 						true:  "(oldest first)",
 						false: "(newest first)",
-					}[m.ascending],
+					}[m.sortAscending],
 				),
 			}
 			m.showStatusMessage = true
@@ -581,15 +581,15 @@ func (m *stashModel) handleDocumentBrowsing(msg tea.Msg) tea.Cmd {
 
 		case "t":
 			m.byDate = false
-			m.ascending = !m.ascending
-			sortMarkdowns(m.filteredMarkdowns, m.byDate, sortOrder(m.ascending))
+			m.sortAscending = !m.sortAscending
+			sortMarkdowns(m.filteredMarkdowns, m.byDate, sortOrder(m.sortAscending))
 			m.statusMessage = statusMessage{
 				status: normalStatusMessage,
 				message: fmt.Sprintf("Sorted by title %s",
 					map[bool]string{
 						true:  "(A to Z)",
 						false: "(Z to A)",
-					}[m.ascending],
+					}[m.sortAscending],
 				),
 			}
 			m.showStatusMessage = true
@@ -897,7 +897,7 @@ func filterMarkdowns(m stashModel) tea.Cmd {
 	return func() tea.Msg {
 		if m.filterInput.Value() == "" {
 			m.filteredMarkdowns = m.markdowns
-			sortMarkdowns(m.filteredMarkdowns, m.byDate, sortOrder(m.ascending))
+			sortMarkdowns(m.filteredMarkdowns, m.byDate, sortOrder(m.sortAscending))
 			return filteredMarkdownMsg(m.filteredMarkdowns)
 		}
 

--- a/ui/stashhelp.go
+++ b/ui/stashhelp.go
@@ -115,7 +115,7 @@ func (m stashModel) helpView() (string, int) {
 
 	if numDocs > 0 {
 		sortHelp = []string{
-			"d", "toggle date sort",
+			"y", "toggle date sort",
 			"t", "toggle title sort",
 		}
 	}

--- a/ui/stashhelp.go
+++ b/ui/stashhelp.go
@@ -113,7 +113,8 @@ func (m stashModel) helpView() (string, int) {
 		navHelp = []string{"enter", "open", "j/k ↑/↓", "choose"}
 	}
 
-	if numDocs > 0 {
+	// Only show sort help in full help view
+	if numDocs > 0 && m.showFullHelp {
 		sortHelp = []string{
 			"y", "toggle date sort",
 			"t", "toggle title sort",
@@ -160,7 +161,7 @@ func (m stashModel) helpView() (string, int) {
 	if m.filterState != filtering {
 		appHelp = append(appHelp, "?", "more")
 	}
-	return m.renderHelp(navHelp, sortHelp, filterHelp, selectionHelp, editHelp, sectionHelp, appHelp)
+	return m.renderHelp(navHelp, filterHelp, selectionHelp, editHelp, sectionHelp, appHelp)
 }
 
 const minHelpViewHeight = 5

--- a/ui/stashhelp.go
+++ b/ui/stashhelp.go
@@ -106,10 +106,18 @@ func (m stashModel) helpView() (string, int) {
 		editHelp      []string
 		sectionHelp   []string
 		appHelp       []string
+		sortHelp      []string
 	)
 
 	if numDocs > 0 && m.showFullHelp {
 		navHelp = []string{"enter", "open", "j/k ↑/↓", "choose"}
+	}
+
+	if numDocs > 0 {
+		sortHelp = []string{
+			"d", "toggle date sort",
+			"t", "toggle title sort",
+		}
 	}
 
 	if len(m.sections) > 1 {
@@ -145,14 +153,14 @@ func (m stashModel) helpView() (string, int) {
 		if m.filterState != filtering {
 			appHelp = append(appHelp, "?", "close help")
 		}
-		return m.renderHelp(navHelp, filterHelp, append(selectionHelp, editHelp...), sectionHelp, appHelp)
+		return m.renderHelp(navHelp, sortHelp, filterHelp, append(selectionHelp, editHelp...), sectionHelp, appHelp)
 	}
 
 	// Mini help
 	if m.filterState != filtering {
 		appHelp = append(appHelp, "?", "more")
 	}
-	return m.renderHelp(navHelp, filterHelp, selectionHelp, editHelp, sectionHelp, appHelp)
+	return m.renderHelp(navHelp, sortHelp, filterHelp, selectionHelp, editHelp, sectionHelp, appHelp)
 }
 
 const minHelpViewHeight = 5


### PR DESCRIPTION
* Closes #228

### Describe your changes
Adds the ability to press 'y' to toggle the sort by date. Also adds the ability to press 't' to switch back to sorting by title, and can sort reverse alphabetically by pressing repeatedly. These options now appear in the fullView after pressing '?'.

### Related issue/discussion: https://github.com/charmbracelet/glow/issues/228