### PR TITLE
Fix: prevent crash on edit attempt with no files present

### DIFF
--- a/ui/stash.go
+++ b/ui/stash.go
@@ -518,6 +518,12 @@ func (m *stashModel) handleDocumentBrowsing(msg tea.Msg) tea.Cmd {
 		// Edit document in EDITOR
 		case "e":
 			md := m.selectedMarkdown()
+
+			// In case no file is available
+			if md == nil {
+				return nil
+			}
+
 			return openEditor(md.localPath, 0)
 
 		// Open document

--- a/ui/stashhelp.go
+++ b/ui/stashhelp.go
@@ -137,7 +137,11 @@ func (m stashModel) helpView() (string, int) {
 	}
 
 	appHelp = append(appHelp, "r", "refresh")
-	appHelp = append(appHelp, "e", "edit")
+
+	if numDocs > 0 {
+		appHelp = append(appHelp, "e", "edit")
+	}
+
 	appHelp = append(appHelp, "q", "quit")
 
 	// Detailed help


### PR DESCRIPTION
Hello,
currently, attempting to edit with no files present causes the app to crash because m.selectedMarkdown() returns nil, which leads to a runtime error when it is passed to openEditor().

#### Changes:
- [handle case when selected md is nil, which led to the crash](https://github.com/charmbracelet/glow/commit/b49e1931aaf643ca0aba76564e7c8dc33d721178) 
(tea.Batch seems to handle it gracefully now.)
- [only show edit help if documents are available](https://github.com/charmbracelet/glow/commit/2a4725cade2d9649f932b6e199b458551b78fcb7)

New empty state:
![empty](https://github.com/user-attachments/assets/5ccb305a-8edc-4095-b999-5f6b8cad61ad)
Documents present:
![filled](https://github.com/user-attachments/assets/f51ad40a-705b-4b34-b352-9920877b57cd)

#### This will close https://github.com/charmbracelet/glow/issues/766

I also created a [version](https://github.com/MarkusBillharz/glow/compare/task/fix_edit_crash_on_empty_stash...MarkusBillharz:glow:task/create_file_if_stash_is_empty) on top of this fix that points to a default file instead, but wasn’t sure if that aligns with your project’s goals.

Thanks!~
