### PR TITLE
fix: expand path before rendering style

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -75,7 +75,7 @@ func GlamourStyle(style string, isCode bool) glamour.TermRendererOption {
 		if style == styles.AutoStyle {
 			return glamour.WithAutoStyle()
 		}
-		return glamour.WithStylePath(style)
+		return glamour.WithStylePath(ExpandPath(style))
 	}
 
 	// If we are rendering a pure code block, we need to modify the style to


### PR DESCRIPTION
### Describe your changes

This PR attempts to solve https://github.com/charmbracelet/glow/issues/776 (and links therein).

It seems `ExpandPath` is not invoked when resolving the styles but only in `validateStyle(style string)` instead.