### PR TITLE
fix: resolve layout glitch when resizing the window

### DIFF
--- a/ui/stash.go
+++ b/ui/stash.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/glow/v2/utils"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/log"
 	"github.com/muesli/reflow/ansi"
@@ -860,7 +861,7 @@ func loadLocalMarkdown(md *markdown) tea.Cmd {
 			log.Debug("error reading local file", "error", err)
 			return errMsg{err}
 		}
-		md.Body = string(data)
+		md.Body = string(utils.RemoveFrontmatter(data))
 		return fetchedMarkdownMsg(md)
 	}
 }

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -175,6 +175,7 @@ func newModel(cfg Config, content string) tea.Model {
 		m.state = stateShowDocument
 		m.pager.currentDocument = markdown{
 			localPath: path,
+			Body:      content,
 			Note:      stripAbsolutePath(path, cwd),
 			Modtime:   info.ModTime(),
 		}


### PR DESCRIPTION
Ensures markdown content is rendered correctly after window resize. Previously, resizing could break layout due to improper initialization.

Closes #787

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code