### PR TITLE
fix: respect all config file provided width values

### DIFF
--- a/config_cmd.go
+++ b/config_cmd.go
@@ -20,7 +20,7 @@ mouse: false
 # use pager to display markdown
 pager: false
 # word-wrap at width
-width: 80
+width: 0
 # show all files, including hidden and ignored.
 all: false
 `

--- a/main.go
+++ b/main.go
@@ -189,22 +189,6 @@ func validateOptions(cmd *cobra.Command) error {
 		style = "notty"
 	}
 
-	// Detect terminal width
-	if !cmd.Flags().Changed("width") { //nolint:nestif
-		if isTerminal && width == 0 {
-			w, _, err := term.GetSize(int(os.Stdout.Fd()))
-			if err == nil {
-				width = uint(w) //nolint:gosec
-			}
-
-			if width > 120 {
-				width = 120
-			}
-		}
-		if width == 0 {
-			width = 80
-		}
-	}
 	return nil
 }
 


### PR DESCRIPTION
### Describe your changes

This PR aims to address #752 where width values specified in the config file below 80 or above 120 are effectively ignored, including the special value of `0`.

To do this, the default value written to the config file is set to `0` to mirror the viper default for `width`, and the special casing to restrict with width when not user specified has been removed. Users with a pre-existing config file will still maintain the previously set value of `80`, and should still see the previous behavior.

Fixes #752

### Related issue/discussion: #752

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
