### PR TITLE
Add support for stream input

### DIFF
--- a/flow.go
+++ b/flow.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/glamour"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+)
+
+func executeWithFlow(cmd *cobra.Command, src *source, w io.Writer) error {
+	var line string
+	var nextLine string
+	for {
+		b := make([]byte, 1024)
+		n, err := src.reader.Read(b)
+		if err != nil {
+			if err == io.EOF {
+				if n == 0 && nextLine == "" {
+					return nil
+				}
+			} else {
+				return fmt.Errorf("unable to read from reader: %w", err)
+			}
+		}
+
+		if n == 0 && nextLine == "" {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
+		// if buffered nextlin exists, update current line
+		if nextLine != "" {
+			line = strings.TrimLeft(nextLine, "\n")
+			if strings.HasPrefix(nextLine, "\n") {
+				fmt.Fprint(w, "\n")
+			}
+			nextLine = ""
+		}
+
+		chunk := strings.ReplaceAll(string(b[:n]), "\r", "")
+		fullLine := line + chunk
+
+		if i := strings.IndexAny(fullLine, "\n"); i != -1 {
+			line = fullLine[:i+1]
+			if len(fullLine) > i+1 {
+				nextLine = fullLine[i+1:]
+			}
+		} else {
+			line = fullLine
+		}
+
+		if strings.HasSuffix(line, "\n") {
+			fmt.Fprint(w, "\r"+line)
+			line = ""
+			continue
+		}
+		if len(line) > int(width) {
+			continue
+		}
+		fmt.Fprint(w, "\r"+line)
+	}
+}
+
+func renderString(in string) string {
+	// TODO: Implement flow rendering logic
+
+	r, err := glamour.NewTermRenderer(
+		glamour.WithColorProfile(lipgloss.ColorProfile()),
+		glamour.WithAutoStyle(),
+		glamour.WithWordWrap(int(width)), //nolint:gosec
+		glamour.WithBaseURL(baseURL),
+		glamour.WithPreservedNewLines(),
+	)
+
+	if err != nil {
+		panic("err on creating renderer")
+	}
+
+	
+
+	/////////***********************
+
+	// b = utils.RemoveFrontmatter(b)
+
+	// styleOptions := utils.GlamourStyle(style, isCode)
+
+	// // initialize glamour
+	// r, err := glamour.NewTermRenderer(
+	// 	glamour.WithColorProfile(lipgloss.ColorProfile()),
+	// 	styleOptions,
+	// 	glamour.WithWordWrap(int(width)), //nolint:gosec
+	// 	glamour.WithBaseURL(baseURL),
+	// 	glamour.WithPreservedNewLines(),
+	// )
+	// if err != nil {
+	// 	return fmt.Errorf("unable to create renderer: %w", err)
+	// }
+
+	// content := string(b[:n])
+
+	// if isCode {
+	// 	content = utils.WrapCodeBlock(string(b), ext)
+	// }
+	// line = line + string(b[:n])
+	// out, err := r.Render(line)
+	// rend := "\r" + strings.TrimRight(out, "\n")
+	// if err != nil {
+	// 	return fmt.Errorf("unable to render markdown: %w", err)
+	// }
+
+	// // display
+	// switch {
+	// case pager || cmd.Flags().Changed("pager"):
+	// 	pagerCmd := os.Getenv("PAGER")
+	// 	if pagerCmd == "" {
+	// 		pagerCmd = "less -r"
+	// 	}
+
+	// 	pa := strings.Split(pagerCmd, " ")
+	// 	c := exec.Command(pa[0], pa[1:]...) //nolint:gosec
+	// 	c.Stdin = strings.NewReader(out)
+	// 	c.Stdout = os.Stdout
+	// 	if err := c.Run(); err != nil {
+	// 		return fmt.Errorf("unable to run command: %w", err)
+	// 	}
+	// 	return nil
+	// case tui || cmd.Flags().Changed("tui"):
+	// 	path := ""
+	// 	if !isURL(src.URL) {
+	// 		path = src.URL
+	// 	}
+	// 	return runTUI(path, content)
+	// default:
+	// 	if _, err = fmt.Fprint(w, rend); err != nil {
+	// 		return fmt.Errorf("unable to write to writer: %w", err)
+	// 	}
+	// }
+}

--- a/flow.go
+++ b/flow.go
@@ -7,8 +7,18 @@ import (
 	"time"
 
 	"github.com/charmbracelet/glamour"
+	"github.com/charmbracelet/glamour/ansi"
+	"github.com/charmbracelet/glamour/styles"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
+)
+
+type TextPosition int
+
+const (
+	TextStart TextPosition = iota
+	TextMiddle
+	TextEnd
 )
 
 func executeWithFlow(cmd *cobra.Command, src *source, w io.Writer) error {
@@ -19,8 +29,21 @@ func executeWithFlow(cmd *cobra.Command, src *source, w io.Writer) error {
 		n, err := src.reader.Read(b)
 		if err != nil {
 			if err == io.EOF {
-				if n == 0 && nextLine == "" {
-					return nil
+				if n == 0 {
+					if len(line) > 0 {
+						out := renderString(line, "NOT USED NOW", TextStart)
+						if strings.HasPrefix(line, "\n") {
+							fmt.Fprint(w, "\n")
+						}
+						fmt.Fprint(w, "\r"+out)
+						if strings.HasSuffix(line, "\n") {
+							fmt.Fprint(w, "\n")
+						}
+						line = ""
+					}
+					if nextLine == "" {
+						return nil
+					}
 				}
 			} else {
 				return fmt.Errorf("unable to read from reader: %w", err)
@@ -53,90 +76,65 @@ func executeWithFlow(cmd *cobra.Command, src *source, w io.Writer) error {
 			line = fullLine
 		}
 
+		out := renderString(line, "NOT USED NOW", TextStart)
+
 		if strings.HasSuffix(line, "\n") {
-			fmt.Fprint(w, "\r"+line)
+
+			if strings.HasPrefix(line, "\n") {
+				fmt.Fprint(w, "\n")
+			}
+			fmt.Fprint(w, "\r"+out)
+			if strings.HasSuffix(line, "\n") {
+				fmt.Fprint(w, "\n")
+			}
+
 			line = ""
 			continue
 		}
 		if len(line) > int(width) {
 			continue
 		}
-		fmt.Fprint(w, "\r"+line)
+		if strings.HasPrefix(line, "\n") {
+			fmt.Fprint(w, "\n")
+		}
+		fmt.Fprint(w, "\r"+out)
+		if strings.HasSuffix(line, "\n") {
+			fmt.Fprint(w, "\n")
+		}
 	}
 }
 
-func renderString(in string) string {
-	// TODO: Implement flow rendering logic
+func renderString(in string, style string, position TextPosition) string {
+
+	var styleConfig ansi.StyleConfig
+
+	// Get style
+	if lipgloss.HasDarkBackground() {
+		styleConfig = styles.DarkStyleConfig
+	} else {
+		styleConfig = styles.LightStyleConfig
+	}
+
+	m := uint(2)
+	styleConfig.Document.BlockPrefix = ""
+	styleConfig.Document.BlockSuffix = ""
+	styleConfig.Document.Margin = &m
 
 	r, err := glamour.NewTermRenderer(
 		glamour.WithColorProfile(lipgloss.ColorProfile()),
-		glamour.WithAutoStyle(),
-		glamour.WithWordWrap(int(width)), //nolint:gosec
-		glamour.WithBaseURL(baseURL),
-		glamour.WithPreservedNewLines(),
+		glamour.WithStyles(styleConfig),
+		glamour.WithWordWrap(int(0)), //nolint:gosec
 	)
 
 	if err != nil {
-		panic("err on creating renderer")
+		panic("ERRRORRR")
 	}
 
-	
+	out, _ := r.Render(in)
+	out = strings.ReplaceAll(out, "\n", "")
+	return out
+}
 
-	/////////***********************
-
-	// b = utils.RemoveFrontmatter(b)
-
-	// styleOptions := utils.GlamourStyle(style, isCode)
-
-	// // initialize glamour
-	// r, err := glamour.NewTermRenderer(
-	// 	glamour.WithColorProfile(lipgloss.ColorProfile()),
-	// 	styleOptions,
-	// 	glamour.WithWordWrap(int(width)), //nolint:gosec
-	// 	glamour.WithBaseURL(baseURL),
-	// 	glamour.WithPreservedNewLines(),
-	// )
-	// if err != nil {
-	// 	return fmt.Errorf("unable to create renderer: %w", err)
-	// }
-
-	// content := string(b[:n])
-
-	// if isCode {
-	// 	content = utils.WrapCodeBlock(string(b), ext)
-	// }
-	// line = line + string(b[:n])
-	// out, err := r.Render(line)
-	// rend := "\r" + strings.TrimRight(out, "\n")
-	// if err != nil {
-	// 	return fmt.Errorf("unable to render markdown: %w", err)
-	// }
-
-	// // display
-	// switch {
-	// case pager || cmd.Flags().Changed("pager"):
-	// 	pagerCmd := os.Getenv("PAGER")
-	// 	if pagerCmd == "" {
-	// 		pagerCmd = "less -r"
-	// 	}
-
-	// 	pa := strings.Split(pagerCmd, " ")
-	// 	c := exec.Command(pa[0], pa[1:]...) //nolint:gosec
-	// 	c.Stdin = strings.NewReader(out)
-	// 	c.Stdout = os.Stdout
-	// 	if err := c.Run(); err != nil {
-	// 		return fmt.Errorf("unable to run command: %w", err)
-	// 	}
-	// 	return nil
-	// case tui || cmd.Flags().Changed("tui"):
-	// 	path := ""
-	// 	if !isURL(src.URL) {
-	// 		path = src.URL
-	// 	}
-	// 	return runTUI(path, content)
-	// default:
-	// 	if _, err = fmt.Fprint(w, rend); err != nil {
-	// 		return fmt.Errorf("unable to write to writer: %w", err)
-	// 	}
-	// }
+func writeRendered(w io.Writer, line, out string) {
+	// TODO: move write code here
 }

--- a/flow.go
+++ b/flow.go
@@ -32,13 +32,7 @@ func executeWithFlow(cmd *cobra.Command, src *source, w io.Writer) error {
 				if n == 0 {
 					if len(line) > 0 {
 						out := renderString(line, "NOT USED NOW", TextStart)
-						if strings.HasPrefix(line, "\n") {
-							fmt.Fprint(w, "\n")
-						}
-						fmt.Fprint(w, "\r"+out)
-						if strings.HasSuffix(line, "\n") {
-							fmt.Fprint(w, "\n")
-						}
+						writeRendered(w, &line, &out)
 						line = ""
 					}
 					if nextLine == "" {
@@ -80,13 +74,7 @@ func executeWithFlow(cmd *cobra.Command, src *source, w io.Writer) error {
 
 		if strings.HasSuffix(line, "\n") {
 
-			if strings.HasPrefix(line, "\n") {
-				fmt.Fprint(w, "\n")
-			}
-			fmt.Fprint(w, "\r"+out)
-			if strings.HasSuffix(line, "\n") {
-				fmt.Fprint(w, "\n")
-			}
+			writeRendered(w, &line, &out)
 
 			line = ""
 			continue
@@ -94,13 +82,7 @@ func executeWithFlow(cmd *cobra.Command, src *source, w io.Writer) error {
 		if len(line) > int(width) {
 			continue
 		}
-		if strings.HasPrefix(line, "\n") {
-			fmt.Fprint(w, "\n")
-		}
-		fmt.Fprint(w, "\r"+out)
-		if strings.HasSuffix(line, "\n") {
-			fmt.Fprint(w, "\n")
-		}
+		writeRendered(w, &line, &out)
 	}
 }
 
@@ -127,7 +109,7 @@ func renderString(in string, style string, position TextPosition) string {
 	)
 
 	if err != nil {
-		panic("ERRRORRR")
+		panic(err)
 	}
 
 	out, _ := r.Render(in)
@@ -135,6 +117,13 @@ func renderString(in string, style string, position TextPosition) string {
 	return out
 }
 
-func writeRendered(w io.Writer, line, out string) {
-	// TODO: move write code here
+func writeRendered(w io.Writer, line, out *string) {
+	if strings.HasPrefix(*line, "\n") {
+		fmt.Fprint(w, "\n")
+	}
+	fmt.Fprint(w, "\r", strings.Repeat(" ", int(width)))
+	fmt.Fprint(w, "\r"+(*out))
+	if strings.HasSuffix(*line, "\n") {
+		fmt.Fprint(w, "\n")
+	}
 }

--- a/main.go
+++ b/main.go
@@ -43,6 +43,8 @@ var (
 	preserveNewLines bool
 	mouse            bool
 
+	flow bool
+
 	rootCmd = &cobra.Command{
 		Use:   "glow [SOURCE|DIR]",
 		Short: "Render markdown on the CLI, with pizzazz!",
@@ -271,6 +273,9 @@ func executeArg(cmd *cobra.Command, arg string, w io.Writer) error {
 }
 
 func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
+	if flow {
+		return executeWithFlow(cmd, src, w)
+	}
 	b, err := io.ReadAll(src.reader)
 	if err != nil {
 		return fmt.Errorf("unable to read from reader: %w", err)
@@ -403,6 +408,7 @@ func init() {
 	rootCmd.Flags().BoolVarP(&showLineNumbers, "line-numbers", "l", false, "show line numbers (TUI-mode only)")
 	rootCmd.Flags().BoolVarP(&preserveNewLines, "preserve-new-lines", "n", false, "preserve newlines in the output")
 	rootCmd.Flags().BoolVarP(&mouse, "mouse", "m", false, "enable mouse wheel (TUI-mode only)")
+	rootCmd.Flags().BoolVar(&flow, "flow", false, "render flow input on terminal")
 	_ = rootCmd.Flags().MarkHidden("mouse")
 
 	// Config bindings


### PR DESCRIPTION
### Add support for stream

Currently glow waits input stream be closed and after that renders full content. With this feature input could be rendered to markdown in real time, added `--flow` flag to enable this mode.

This feature could be used with LLM's output
ex. `ollama run gemma3:4b "Create list of 5 fruits" | glow --flow`

**Important** If same text created multiple lines, then use `-w` flag to specify terminal width, glow  couldn't automatically detect terminal size and set it to default value 80 or 120 which could be bigger than actual terminal size. 

### Limitations in this mode
* no code highlighting
* no styles 
* not supports tui and pager

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
