### PR TITLE
Add conda to package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ gpgkey=https://repo.charm.sh/yum/gpg.key' | sudo tee /etc/yum.repos.d/charm.repo
 sudo yum install glow
 ```
 
+```bash
+# conda-forge (cross platform Linux, macOS and Windows)
+pixi global install glow-md
+```
+
 Or download a binary from the [releases][releases] page. MacOS, Linux, Windows,
 FreeBSD and OpenBSD binaries are available, as well as Debian, RPM, and Alpine
 packages. ARM builds are also available for macOS, Linux, FreeBSD and OpenBSD.


### PR DESCRIPTION
### Describe your changes

[pixi](https://pixi.sh) is a modern package manager for the conda ecosystem that works on macOS, Linux and Windows.
Glow is also packaged on conda-forge: https://prefix.dev/channels/conda-forge/packages/glow-md

### Related issue/discussion: <insert link>

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
