### PR TITLE
fix: handle UTF-16 LE/BE encoded files with BOM

### DIFF
--- a/console_windows.go
+++ b/console_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package main

--- a/main.go
+++ b/main.go
@@ -276,7 +276,9 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 		return fmt.Errorf("unable to read from reader: %w", err)
 	}
 
-	b = utils.RemoveFrontmatter(b)
+	// Convert to UTF-8 (handles UTF-16 LE/BE with BOM)
+	content := utils.ToUTF8String(b)
+	content = string(utils.RemoveFrontmatter([]byte(content)))
 
 	// render
 	var baseURL string
@@ -300,10 +302,9 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 		return fmt.Errorf("unable to create renderer: %w", err)
 	}
 
-	content := string(b)
 	ext := filepath.Ext(src.URL)
 	if isCode {
-		content = utils.WrapCodeBlock(string(b), ext)
+		content = utils.WrapCodeBlock(content, ext)
 	}
 
 	out, err := r.Render(content)

--- a/ui/stash.go
+++ b/ui/stash.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/glow/v2/utils"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/log"
 	"github.com/muesli/reflow/ansi"
@@ -860,7 +861,7 @@ func loadLocalMarkdown(md *markdown) tea.Cmd {
 			log.Debug("error reading local file", "error", err)
 			return errMsg{err}
 		}
-		md.Body = string(data)
+		md.Body = utils.ToUTF8String(data)
 		return fetchedMarkdownMsg(md)
 	}
 }

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -195,7 +195,9 @@ func (m model) Init() tea.Cmd {
 			log.Error("unable to read file", "file", m.common.cfg.Path, "error", err)
 			return func() tea.Msg { return errMsg{err} }
 		}
-		body := string(utils.RemoveFrontmatter(content))
+		// Convert to UTF-8 (handles UTF-16 LE/BE with BOM)
+		utf8Content := utils.ToUTF8String(content)
+		body := string(utils.RemoveFrontmatter([]byte(utf8Content)))
 		cmds = append(cmds, renderWithGlamour(m.pager, body))
 	}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,6 +2,7 @@
 package utils
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -12,7 +13,47 @@ import (
 	"github.com/charmbracelet/glamour/styles"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/mitchellh/go-homedir"
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
 )
+
+// UTF-8 BOM bytes.
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// ToUTF8String converts bytes to a UTF-8 string, handling UTF-16 LE/BE with BOM
+// and UTF-8 with BOM. If no BOM is detected, the bytes are assumed to be UTF-8.
+func ToUTF8String(data []byte) string {
+	if len(data) < 2 {
+		return string(data)
+	}
+
+	// UTF-16 LE BOM: 0xFF 0xFE
+	if data[0] == 0xFF && data[1] == 0xFE {
+		decoder := unicode.UTF16(unicode.LittleEndian, unicode.ExpectBOM).NewDecoder()
+		result, _, err := transform.Bytes(decoder, data)
+		if err == nil {
+			return string(result)
+		}
+		// Fall through to return as-is on error
+	}
+
+	// UTF-16 BE BOM: 0xFE 0xFF
+	if data[0] == 0xFE && data[1] == 0xFF {
+		decoder := unicode.UTF16(unicode.BigEndian, unicode.ExpectBOM).NewDecoder()
+		result, _, err := transform.Bytes(decoder, data)
+		if err == nil {
+			return string(result)
+		}
+		// Fall through to return as-is on error
+	}
+
+	// UTF-8 BOM: 0xEF 0xBB 0xBF - just strip it
+	if bytes.HasPrefix(data, utf8BOM) {
+		return string(data[3:])
+	}
+
+	return string(data)
+}
 
 // RemoveFrontmatter removes the front matter header of a markdown file.
 func RemoveFrontmatter(content []byte) []byte {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,95 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestToUTF8String(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected string
+	}{
+		{
+			name:     "plain UTF-8",
+			input:    []byte("Hello, World!"),
+			expected: "Hello, World!",
+		},
+		{
+			name:     "UTF-8 with BOM",
+			input:    []byte{0xEF, 0xBB, 0xBF, 'H', 'e', 'l', 'l', 'o'},
+			expected: "Hello",
+		},
+		{
+			name: "UTF-16 LE with BOM",
+			input: []byte{
+				0xFF, 0xFE, // BOM
+				'H', 0x00, 'e', 0x00, 'l', 0x00, 'l', 0x00, 'o', 0x00,
+			},
+			expected: "Hello",
+		},
+		{
+			name: "UTF-16 BE with BOM",
+			input: []byte{
+				0xFE, 0xFF, // BOM
+				0x00, 'H', 0x00, 'e', 0x00, 'l', 0x00, 'l', 0x00, 'o',
+			},
+			expected: "Hello",
+		},
+		{
+			name:     "empty input",
+			input:    []byte{},
+			expected: "",
+		},
+		{
+			name:     "single byte",
+			input:    []byte{'A'},
+			expected: "A",
+		},
+		{
+			name: "UTF-16 LE with markdown content",
+			input: []byte{
+				0xFF, 0xFE, // BOM
+				'#', 0x00, ' ', 0x00, 'T', 0x00, 'e', 0x00, 's', 0x00, 't', 0x00,
+			},
+			expected: "# Test",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ToUTF8String(tc.input)
+			if result != tc.expected {
+				t.Errorf("ToUTF8String(%v) = %q, want %q", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestRemoveFrontmatter(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected []byte
+	}{
+		{
+			name:     "no frontmatter",
+			input:    []byte("# Hello\n\nWorld"),
+			expected: []byte("# Hello\n\nWorld"),
+		},
+		{
+			name:     "with frontmatter",
+			input:    []byte("---\ntitle: Test\n---\n# Hello"),
+			expected: []byte("# Hello"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := RemoveFrontmatter(tc.input)
+			if string(result) != string(tc.expected) {
+				t.Errorf("RemoveFrontmatter(%q) = %q, want %q", tc.input, result, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #513

## Changes
- Add `ToUTF8String()` utility function to detect and convert UTF-16 LE/BE with BOM to UTF-8
- Apply encoding conversion in CLI mode, TUI file view, and stash loading
- Add comprehensive tests for encoding conversion