### PR TITLE
fix: Line breaks aren't properly ignored in lists

### DIFF
--- a/main.go
+++ b/main.go
@@ -289,13 +289,16 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 	isCode := !utils.IsMarkdownFile(src.URL)
 
 	// initialize glamour
-	r, err := glamour.NewTermRenderer(
+	options := []glamour.TermRendererOption{
 		glamour.WithColorProfile(lipgloss.ColorProfile()),
 		utils.GlamourStyle(style, isCode),
 		glamour.WithWordWrap(int(width)), //nolint:gosec
 		glamour.WithBaseURL(baseURL),
-		glamour.WithPreservedNewLines(),
-	)
+	}
+	if preserveNewLines {
+		options = append(options, glamour.WithPreservedNewLines())
+	}
+	r, err := glamour.NewTermRenderer(options...)
 	if err != nil {
 		return fmt.Errorf("unable to create renderer: %w", err)
 	}


### PR DESCRIPTION
Fixes #858

## Changes
- Make `WithPreservedNewLines()` conditional based on the `--preserve-new-lines` flag
- Default behavior now correctly treats soft line breaks as spaces in lists

Previously, `glamour.WithPreservedNewLines()` was always applied, causing all line breaks (including soft breaks in lists) to be preserved. Now it respects the CLI flag.