### PR TITLE
Add installation instructions for openSUSE Tumbleweed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ gpgkey=https://repo.charm.sh/yum/gpg.key' | sudo tee /etc/yum.repos.d/charm.repo
 sudo yum install glow
 ```
 
+```bash
+# openSUSE Tumbleweed
+sudo zypper install glow
+```
+
 Or download a binary from the [releases][releases] page. MacOS, Linux, Windows,
 FreeBSD and OpenBSD binaries are available, as well as Debian, RPM, and Alpine
 packages. ARM builds are also available for macOS, Linux, FreeBSD and OpenBSD.


### PR DESCRIPTION
I added the installation instructions for openSUSE Tumbleweed (with Zypper).

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
