### PR TITLE
Follow relative markdown links in the TUI pager (#441)

### DIFF
--- a/ui/keys.go
+++ b/ui/keys.go
@@ -1,6 +1,9 @@
 package ui
 
 const (
-	keyEnter = "enter"
-	keyEsc   = "esc"
+	keyTab       = "tab"
+	keyShiftTab  = "shift+tab"
+	keyEnter     = "enter"
+	keyBackspace = "backspace"
+	keyEsc       = "esc"
 )

--- a/ui/pager_highlight.go
+++ b/ui/pager_highlight.go
@@ -1,0 +1,108 @@
+package ui
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+func highlightFocusedLink(rendered string, links []followableLink, focused int) string {
+	if focused < 0 || focused >= len(links) {
+		return rendered
+	}
+
+	printable, offsets := printableRunesAndOffsets(rendered)
+	if len(printable) == 0 {
+		return rendered
+	}
+	printableStr := string(printable)
+
+	type span struct {
+		start int
+		end   int
+		ok    bool
+	}
+
+	spans := make([]span, len(links))
+	searchFrom := 0
+	for i, l := range links {
+		label := strings.TrimSpace(l.Label)
+		if label == "" || searchFrom >= len(printableStr) {
+			continue
+		}
+
+		relIdx := strings.Index(printableStr[searchFrom:], label)
+		if relIdx < 0 {
+			continue
+		}
+		byteIdx := searchFrom + relIdx
+		searchFrom = byteIdx + len(label)
+
+		startRune := utf8.RuneCountInString(printableStr[:byteIdx])
+		endRune := startRune + utf8.RuneCountInString(label)
+		if startRune < 0 || endRune > len(offsets)-1 {
+			continue
+		}
+
+		startByte := offsets[startRune]
+		endByte := offsets[endRune]
+		if startByte < 0 || endByte < startByte || endByte > len(rendered) {
+			continue
+		}
+
+		spans[i] = span{start: startByte, end: endByte, ok: true}
+	}
+
+	s := spans[focused]
+	if !s.ok {
+		return rendered
+	}
+
+	const (
+		reverseOn  = "\x1b[7m"
+		reverseOff = "\x1b[27m"
+	)
+
+	var b strings.Builder
+	b.Grow(len(rendered) + len(reverseOn) + len(reverseOff))
+	b.WriteString(rendered[:s.start])
+	b.WriteString(reverseOn)
+	b.WriteString(rendered[s.start:s.end])
+	b.WriteString(reverseOff)
+	b.WriteString(rendered[s.end:])
+	return b.String()
+}
+
+func printableRunesAndOffsets(s string) ([]rune, []int) {
+	var (
+		runes   []rune
+		offsets []int
+	)
+
+	for i := 0; i < len(s); {
+		if s[i] == 0x1b && i+1 < len(s) && s[i+1] == '[' {
+			i += 2
+			for i < len(s) {
+				c := s[i]
+				i++
+				if c >= 0x40 && c <= 0x7E {
+					break
+				}
+			}
+			continue
+		}
+
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError && size == 1 {
+			r = rune(s[i])
+			size = 1
+		}
+
+		runes = append(runes, r)
+		offsets = append(offsets, i)
+		i += size
+	}
+
+	offsets = append(offsets, len(s))
+
+	return runes, offsets
+}

--- a/ui/pager_links.go
+++ b/ui/pager_links.go
@@ -1,0 +1,198 @@
+package ui
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
+)
+
+type followableLink struct {
+	Href     string
+	Path     string
+	Fragment string
+	Label    string
+
+	ResolvedPath string
+	ResolvedNote string
+}
+
+type rawLink struct {
+	href  string
+	label string
+}
+
+func followableLinksForDocument(rootDir, currentFilePath, markdown string) ([]followableLink, error) {
+	raw := extractRawLinks(markdown)
+
+	out := make([]followableLink, 0, len(raw))
+	for _, l := range raw {
+		link, ok, err := resolveFollowableLink(rootDir, currentFilePath, l.href)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(l.label) == "" {
+			continue
+		}
+		link.Label = l.label
+		out = append(out, link)
+	}
+	return out, nil
+}
+
+func splitFragment(href string) (path, frag string) {
+	path, frag, ok := strings.Cut(href, "#")
+	if ok {
+		return path, frag
+	}
+	return href, ""
+}
+
+func isAbsoluteOrUNCPath(path string) bool {
+	if strings.HasPrefix(path, "/") {
+		return true
+	}
+	if strings.HasPrefix(path, `\\`) {
+		return true
+	}
+	if len(path) >= 2 {
+		c0 := path[0]
+		if ((c0 >= 'a' && c0 <= 'z') || (c0 >= 'A' && c0 <= 'Z')) && path[1] == ':' {
+			return true
+		}
+	}
+	return filepath.IsAbs(path)
+}
+
+func isFollowableHref(href string) bool {
+	href = strings.TrimSpace(href)
+	href = strings.Trim(href, "<>")
+	hrefLower := strings.ToLower(href)
+
+	if strings.Contains(href, "://") || strings.HasPrefix(hrefLower, "mailto:") {
+		return false
+	}
+
+	path, _ := splitFragment(href)
+	if isAbsoluteOrUNCPath(path) {
+		return false
+	}
+	pathLower := strings.ToLower(path)
+
+	return strings.HasSuffix(pathLower, ".md") || strings.HasSuffix(pathLower, ".markdown")
+}
+
+func extractRawLinks(markdown string) []rawLink {
+	source := []byte(markdown)
+	parser := goldmark.New().Parser()
+	doc := parser.Parse(text.NewReader(source))
+
+	var out []rawLink
+	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+
+		link, ok := n.(*ast.Link)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+
+		href := strings.TrimSpace(string(link.Destination))
+		if href == "" {
+			return ast.WalkContinue, nil
+		}
+
+		var b strings.Builder
+		_ = ast.Walk(link, func(child ast.Node, entering bool) (ast.WalkStatus, error) {
+			if !entering {
+				return ast.WalkContinue, nil
+			}
+			if t, ok := child.(*ast.Text); ok {
+				b.Write(t.Segment.Value(source))
+			}
+			return ast.WalkContinue, nil
+		})
+
+		out = append(out, rawLink{
+			href:  href,
+			label: strings.TrimSpace(b.String()),
+		})
+
+		return ast.WalkContinue, nil
+	})
+
+	return out
+}
+
+func resolveFollowableLink(rootDir, currentFilePath, href string) (followableLink, bool, error) {
+	href = strings.TrimSpace(href)
+	href = strings.Trim(href, "<>")
+
+	if !isFollowableHref(href) {
+		return followableLink{}, false, nil
+	}
+
+	path, frag := splitFragment(href)
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return followableLink{}, false, nil
+	}
+
+	if strings.Contains(path, "%") {
+		if decoded, err := url.PathUnescape(path); err == nil {
+			path = decoded
+		}
+	}
+
+	base := filepath.Dir(currentFilePath)
+	resolved := filepath.Clean(filepath.Join(base, path))
+
+	rootAbs, err := filepath.Abs(rootDir)
+	if err != nil {
+		return followableLink{}, false, fmt.Errorf("abs root dir: %w", err)
+	}
+	resAbs, err := filepath.Abs(resolved)
+	if err != nil {
+		return followableLink{}, false, fmt.Errorf("abs resolved path: %w", err)
+	}
+
+	if rootEval, err := filepath.EvalSymlinks(rootAbs); err == nil {
+		rootAbs = rootEval
+	}
+	if resEval, err := filepath.EvalSymlinks(resAbs); err == nil {
+		resAbs = resEval
+	}
+
+	rel, err := filepath.Rel(rootAbs, resAbs)
+	if err != nil {
+		return followableLink{}, false, nil
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return followableLink{}, false, nil
+	}
+
+	info, statErr := os.Stat(resAbs)
+	if statErr != nil {
+		return followableLink{}, false, nil
+	}
+	if !info.Mode().IsRegular() {
+		return followableLink{}, false, nil
+	}
+
+	return followableLink{
+		Href:         href,
+		Path:         path,
+		Fragment:     frag,
+		ResolvedPath: resAbs,
+		ResolvedNote: stripAbsolutePath(resAbs, rootAbs),
+	}, true, nil
+}

--- a/ui/pager_links_test.go
+++ b/ui/pager_links_test.go
@@ -1,0 +1,254 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFollowableLinksForDocument_CommonFormatsAndSafety(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	outside := filepath.Join(base, "outside")
+
+	mustMkdirAll(t, filepath.Join(root, "docs"))
+	mustMkdirAll(t, outside)
+
+	currentFilePath := filepath.Join(root, "current.md")
+	mustWriteFile(t, currentFilePath, "# Current\n")
+
+	targetMD := filepath.Join(root, "docs", "target.md")
+	targetMarkdown := filepath.Join(root, "docs", "target.markdown")
+	spaceNameMD := filepath.Join(root, "docs", "SPACE NAME.md")
+	mustWriteFile(t, targetMD, "# Target\n")
+	mustWriteFile(t, targetMarkdown, "# Target Markdown\n")
+	mustWriteFile(t, spaceNameMD, "# Space Name\n")
+
+	outsideMD := filepath.Join(outside, "outside.md")
+	mustWriteFile(t, outsideMD, "# Outside\n")
+
+	// A directory with a markdown-looking name should not be followable.
+	dirLooksLikeMD := filepath.Join(root, "docs", "dir.md")
+	mustMkdirAll(t, dirLooksLikeMD)
+
+	rootAbs := absEvalSymlinks(t, root)
+
+	type wantLink struct {
+		Label        string
+		ResolvedPath string
+		ResolvedNote string
+		Fragment     string
+	}
+
+	targetAbs := absEvalSymlinks(t, targetMD)
+	targetMarkdownAbs := absEvalSymlinks(t, targetMarkdown)
+	spaceNameAbs := absEvalSymlinks(t, spaceNameMD)
+
+	cases := []struct {
+		name  string
+		md    string
+		want  []wantLink
+		setup func(t *testing.T)
+	}{
+		{
+			name: "inline_relative_md",
+			md:   "See [Target](docs/target.md).\n",
+			want: []wantLink{{
+				Label:        "Target",
+				ResolvedPath: targetAbs,
+				ResolvedNote: stripAbsolutePath(targetAbs, rootAbs),
+			}},
+		},
+		{
+			name: "reference_relative_md",
+			md:   "See [Target][id].\n\n[id]: docs/target.md\n",
+			want: []wantLink{{
+				Label:        "Target",
+				ResolvedPath: targetAbs,
+				ResolvedNote: stripAbsolutePath(targetAbs, rootAbs),
+			}},
+		},
+		{
+			name: "collapsed_reference_relative_md",
+			md:   "[Target][]\n\n[Target]: docs/target.md\n",
+			want: []wantLink{{
+				Label:        "Target",
+				ResolvedPath: targetAbs,
+				ResolvedNote: stripAbsolutePath(targetAbs, rootAbs),
+			}},
+		},
+		{
+			name: "relative_md_with_fragment",
+			md:   "See [Target](docs/target.md#section).\n",
+			want: []wantLink{{
+				Label:        "Target",
+				ResolvedPath: targetAbs,
+				ResolvedNote: stripAbsolutePath(targetAbs, rootAbs),
+				Fragment:     "section",
+			}},
+		},
+		{
+			name: "destination_in_angle_brackets",
+			md:   "See [Target](<docs/target.md>).\n",
+			want: []wantLink{{
+				Label:        "Target",
+				ResolvedPath: targetAbs,
+				ResolvedNote: stripAbsolutePath(targetAbs, rootAbs),
+			}},
+		},
+		{
+			name: "url_escaped_path_is_unescaped",
+			md:   "See [Space](docs/SPACE%20NAME.md).\n",
+			want: []wantLink{{
+				Label:        "Space",
+				ResolvedPath: spaceNameAbs,
+				ResolvedNote: stripAbsolutePath(spaceNameAbs, rootAbs),
+			}},
+		},
+		{
+			name: "relative_markdown_extension",
+			md:   "See [Target](docs/target.markdown).\n",
+			want: []wantLink{{
+				Label:        "Target",
+				ResolvedPath: targetMarkdownAbs,
+				ResolvedNote: stripAbsolutePath(targetMarkdownAbs, rootAbs),
+			}},
+		},
+		{
+			name: "empty_label_is_ignored",
+			md:   "See [](docs/target.md).\n",
+			want: nil,
+		},
+		{
+			name: "image_is_ignored",
+			md:   "![Alt](docs/target.md)\n",
+			want: nil,
+		},
+		{
+			name: "autolink_relative_is_ignored",
+			md:   "See <docs/target.md>.\n",
+			want: nil,
+		},
+		{
+			name: "bare_path_is_ignored",
+			md:   "docs/target.md\n",
+			want: nil,
+		},
+		{
+			name: "external_http_is_ignored",
+			md:   "See [Ext](https://example.com/docs/target.md).\n",
+			want: nil,
+		},
+		{
+			name: "mailto_is_ignored",
+			md:   "See [Mail](mailto:test@example.com).\n",
+			want: nil,
+		},
+		{
+			name: "non_markdown_extension_is_ignored",
+			md:   "See [Txt](docs/target.txt).\n",
+			want: nil,
+		},
+		{
+			name: "missing_file_is_ignored",
+			md:   "See [Missing](docs/missing.md).\n",
+			want: nil,
+		},
+		{
+			name: "directory_is_ignored_even_if_md_suffix",
+			md:   "See [Dir](docs/dir.md).\n",
+			want: nil,
+		},
+		{
+			name: "absolute_unix_path_is_ignored",
+			md:   "See [Abs](/etc/passwd).\n",
+			want: nil,
+		},
+		{
+			name: "windows_drive_absolute_is_ignored",
+			md:   `See [WinAbs](C:\\Windows\\system32\\a.md).`,
+			want: nil,
+		},
+		{
+			name: "windows_unc_absolute_is_ignored",
+			md:   `See [UNC](\\\\server\\share\\a.md).`,
+			want: nil,
+		},
+		{
+			name: "root_escape_via_dotdot_is_ignored",
+			md:   "See [Escape](../outside/outside.md).\n",
+			want: nil,
+		},
+		{
+			name: "root_escape_via_symlink_is_ignored",
+			md:   "See [Escape](escape/outside.md).\n",
+			want: nil,
+			setup: func(t *testing.T) {
+				t.Helper()
+				escape := filepath.Join(root, "escape")
+				if err := os.Symlink(outside, escape); err != nil {
+					t.Skipf("symlink not supported: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setup != nil {
+				tc.setup(t)
+			}
+
+			got, err := followableLinksForDocument(root, currentFilePath, tc.md)
+			if err != nil {
+				t.Fatalf("followableLinksForDocument returned error: %v", err)
+			}
+
+			if len(got) != len(tc.want) {
+				t.Fatalf("expected %d links, got %d: %+v", len(tc.want), len(got), got)
+			}
+
+			for i := range tc.want {
+				if got[i].Label != tc.want[i].Label {
+					t.Fatalf("link[%d] label: expected %q, got %q", i, tc.want[i].Label, got[i].Label)
+				}
+				if got[i].ResolvedPath != tc.want[i].ResolvedPath {
+					t.Fatalf("link[%d] resolved path: expected %q, got %q", i, tc.want[i].ResolvedPath, got[i].ResolvedPath)
+				}
+				if got[i].ResolvedNote != tc.want[i].ResolvedNote {
+					t.Fatalf("link[%d] resolved note: expected %q, got %q", i, tc.want[i].ResolvedNote, got[i].ResolvedNote)
+				}
+				if got[i].Fragment != tc.want[i].Fragment {
+					t.Fatalf("link[%d] fragment: expected %q, got %q", i, tc.want[i].Fragment, got[i].Fragment)
+				}
+			}
+		})
+	}
+}
+
+func absEvalSymlinks(t *testing.T, path string) string {
+	t.Helper()
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatalf("abs %q: %v", path, err)
+	}
+	if eval, err := filepath.EvalSymlinks(abs); err == nil {
+		return eval
+	}
+	return abs
+}
+
+func mustMkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdirall %q: %v", path, err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path, contents string) {
+	t.Helper()
+	mustMkdirAll(t, filepath.Dir(path))
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("writefile %q: %v", path, err)
+	}
+}


### PR DESCRIPTION
Addresses long-standing issue #441

New discussion thread https://github.com/charmbracelet/glow/discussions/884

Add TUI pager support for following relative links to other local markdown files via:
- Tab/Shift+Tab to select
- Enter to follow links
- Backspace to go back to parent

Only follow relative links that resolve to an existing regular file within the directory Glow was opened in. Reject absolute paths, UNC/drive paths, external URLs, and root-escape attempts. Added tests for this as it is a safety concern.

PR template:

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
