### PR TITLE
fix: word wrapping doesn't work in TUI pager

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -14,6 +14,7 @@ import (
 	"github.com/charmbracelet/log"
 	"github.com/muesli/gitcha"
 	te "github.com/muesli/termenv"
+	"github.com/spf13/viper"
 )
 
 const (
@@ -196,6 +197,7 @@ func (m model) Init() tea.Cmd {
 			return func() tea.Msg { return errMsg{err} }
 		}
 		body := string(utils.RemoveFrontmatter(content))
+		m.pager.setSize(viper.GetInt("width"), 0);
 		cmds = append(cmds, renderWithGlamour(m.pager, body))
 	}
 


### PR DESCRIPTION
# Summary

this pr fixes #878

## Problem

running `glow -t -w 20 README.md` doesn't wrap the words like how it does in the cli version.

## Solution

I made it so that when `stateShowDocument` is set, it updates the `m.pager.viewport.width` to the value of the `-w` flag.

After the solution, running `glow -t -w 20 README.md` wraps the words correctly.

## Example

this is the output for `glow -t -w 20 README.md`:

### Before:
[![glow-before.png](https://i.postimg.cc/d0g0gngZ/glow-before.png)](https://postimg.cc/DWdFXQv7)

### After:
[![glow-after.png](https://i.postimg.cc/KYTb3bs8/glow-after.png)](https://postimg.cc/CZwX93g3)

## Tests

- `go test` passes

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
