### PR TITLE
fix(ui): rendering issues when opening files with -t flag

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -190,13 +190,7 @@ func (m model) Init() tea.Cmd {
 	case stateShowStash:
 		cmds = append(cmds, findLocalFiles(*m.common))
 	case stateShowDocument:
-		content, err := os.ReadFile(m.common.cfg.Path)
-		if err != nil {
-			log.Error("unable to read file", "file", m.common.cfg.Path, "error", err)
-			return func() tea.Msg { return errMsg{err} }
-		}
-		body := string(utils.RemoveFrontmatter(content))
-		cmds = append(cmds, renderWithGlamour(m.pager, body))
+		cmds = append(cmds, loadLocalMarkdown(&m.pager.currentDocument))
 	}
 
 	return tea.Batch(cmds...)


### PR DESCRIPTION
Fixes #878

## Problem

When opening a file directly in TUI mode (`glow -t README.md` or `glow -w 60 -t README.md`), the `-w` (word wrap width) flag was ignored. The word wrap only took effect after escaping from edit mode.

## Root Cause

In `ui/ui.go`, the `Init()` function read the file content and passed it to `renderWithGlamour()` but never stored the body in `currentDocument.Body`. When the first `WindowSizeMsg` arrived (which sets the correct viewport dimensions), the pager attempted to re-render using `currentDocument.Body` — which was an empty string. This caused the initial render (done before viewport dimensions were known) to be discarded and replaced with a blank re-render, effectively ignoring the configured word wrap width.

## Fix

Replaced the manual file read in `Init()` with `loadLocalMarkdown()`, which:

1. Reads the file from disk
2. Stores the content in `currentDocument.Body`
3. Emits a `fetchedMarkdownMsg` that triggers rendering with the correct body

This ensures that when `WindowSizeMsg` triggers a re-render, `currentDocument.Body` contains the actual file content, and the word wrap width is applied correctly.

## Changed File

- **`ui/ui.go`** — Replaced inline file reading in `Init()` with a call to `loadLocalMarkdown(&m.pager.currentDocument)`.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
