### PR TITLE
fix: use true color for `code_block` rendering if support detected

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/log"
 	gap "github.com/muesli/go-app-paths"
+	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/term"
@@ -208,6 +209,19 @@ func validateOptions(cmd *cobra.Command) error {
 	return nil
 }
 
+func chromaFormatter(p termenv.Profile) string {
+	switch p {
+	case termenv.TrueColor:
+		return "terminal16m"
+	case termenv.ANSI256:
+		return "terminal256"
+	case termenv.ANSI:
+		return "terminal16"
+	default:
+		return "terminal"
+	}
+}
+
 func stdinIsPipe() (bool, error) {
 	stat, err := os.Stdin.Stat()
 	if err != nil {
@@ -289,8 +303,10 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 	isCode := !utils.IsMarkdownFile(src.URL)
 
 	// initialize glamour
+	colorProfile := lipgloss.ColorProfile()
 	r, err := glamour.NewTermRenderer(
-		glamour.WithColorProfile(lipgloss.ColorProfile()),
+		glamour.WithColorProfile(colorProfile),
+		glamour.WithChromaFormatter(chromaFormatter(colorProfile)),
 		utils.GlamourStyle(style, isCode),
 		glamour.WithWordWrap(int(width)), //nolint:gosec
 		glamour.WithBaseURL(baseURL),


### PR DESCRIPTION
There is a bug in how `code_block` is rendered, currently 256 colors palette is used regardless whether true color is detected or not. To reproduce just render any markdown document which contains \`\`\`language... colors will be off because they are quantized to nearest color from 256 palette.

Here is example is before (top) and after (bottom)
<img width="1101" height="1231" alt="image" src="https://github.com/user-attachments/assets/f7fcb902-d827-405f-a055-67b64fc16c26" />

This change correctly initializes true color in `Chroma` library