### PR TITLE
feat: add presentation mode for slide-based navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,21 @@ Markdown files can be read with Glow's high-performance pager. Most of the
 keystrokes you know from `less` are the same, but you can press `?` to list
 the hotkeys.
 
+### Presentation Mode
+
+Glow can be used as a presentation tool for markdown files. When presentation
+mode is enabled, Glow splits the document into slides based on numbered H1
+headers (e.g. `# 1 Introduction`, `# 2 Details`) and displays them one at a
+time.
+
+```bash
+# Present a markdown file as slides
+glow -P presentation.md
+```
+
+Navigate between slides with `n`/`right` and `p`/`left`. A slide indicator in
+the status bar shows your current position (e.g. `[Slide 1/5]`).
+
 ## The CLI
 
 In addition to a TUI, Glow has a CLI for working with Markdown. To format a

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ var (
 	configFile       string
 	pager            bool
 	tui              bool
+	presentation     bool
 	style            string
 	width            uint
 	showAllFiles     bool
@@ -168,12 +169,21 @@ func validateOptions(cmd *cobra.Command) error {
 	mouse = viper.GetBool("mouse")
 	pager = viper.GetBool("pager")
 	tui = viper.GetBool("tui")
+	presentation = viper.GetBool("presentation")
 	showAllFiles = viper.GetBool("all")
 	preserveNewLines = viper.GetBool("preserveNewLines")
 	showLineNumbers = viper.GetBool("showLineNumbers")
 
 	if pager && tui {
 		return errors.New("cannot use both pager and tui")
+	}
+
+	if pager && presentation {
+		return errors.New("presentation mode cannot be used with pager mode")
+	}
+
+	if presentation && !tui {
+		tui = true
 	}
 
 	// validate the glamour style
@@ -359,6 +369,7 @@ func runTUI(path string, content string) error {
 	cfg.GlamourMaxWidth = width
 	cfg.EnableMouse = mouse
 	cfg.PreserveNewLines = preserveNewLines
+	cfg.PresentationMode = presentation
 
 	// Run Bubble Tea program
 	if _, err := ui.NewProgram(cfg, content).Run(); err != nil {
@@ -397,6 +408,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&configFile, "config", "", fmt.Sprintf("config file (default %s)", viper.GetViper().ConfigFileUsed()))
 	rootCmd.Flags().BoolVarP(&pager, "pager", "p", false, "display with pager")
 	rootCmd.Flags().BoolVarP(&tui, "tui", "t", false, "display with tui")
+	rootCmd.Flags().BoolVarP(&presentation, "presentation", "P", false, "display in presentation mode (TUI-mode only)")
 	rootCmd.Flags().StringVarP(&style, "style", "s", styles.AutoStyle, "style name or JSON path")
 	rootCmd.Flags().UintVarP(&width, "width", "w", 0, "word-wrap at width (set to 0 to disable)")
 	rootCmd.Flags().BoolVarP(&showAllFiles, "all", "a", false, "show system files and directories (TUI-mode only)")
@@ -408,6 +420,7 @@ func init() {
 	// Config bindings
 	_ = viper.BindPFlag("pager", rootCmd.Flags().Lookup("pager"))
 	_ = viper.BindPFlag("tui", rootCmd.Flags().Lookup("tui"))
+	_ = viper.BindPFlag("presentation", rootCmd.Flags().Lookup("presentation"))
 	_ = viper.BindPFlag("style", rootCmd.Flags().Lookup("style"))
 	_ = viper.BindPFlag("width", rootCmd.Flags().Lookup("width"))
 	_ = viper.BindPFlag("debug", rootCmd.Flags().Lookup("debug"))

--- a/ui/config.go
+++ b/ui/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	GlamourStyle     string `env:"GLAMOUR_STYLE"`
 	EnableMouse      bool
 	PreserveNewLines bool
+	PresentationMode bool
 
 	// Working directory or file path
 	Path string


### PR DESCRIPTION
## Summary

- Adds a presentation mode (`-P` / `--presentation`) that splits documents into slides based on numbered H1 headers (e.g. `# 1 Introduction`, `# 2 Details`)
- Navigate between slides with `n`/`right` and `p`/`left` keys, with a slide indicator in the status bar showing current position
- Presentation mode implies TUI mode and is incompatible with pager mode; can also be enabled via config file (`presentation: true`)

## Files changed

- `main.go` — new `--presentation` / `-P` flag, config binding, validation
- `ui/config.go` — new `PresentationMode` field
- `ui/pager.go` — slide parsing, navigation, keybindings, status bar indicator
- `ui/ui.go` — hook slide parsing into document load flow
- `README.md` — document the new feature

## Test plan

- [ ] `go test ./...` passes
- [ ] `glow -P <file>.md` with numbered H1 headers renders first slide, `n`/`p` navigate between slides
- [ ] Slide indicator `[Slide X/Y]` appears in status bar
- [ ] `glow -P` on a file without numbered H1 headers falls back to normal rendering
- [ ] `glow -p -P` returns an error about incompatible flags
- [ ] `glow -P` without `-t` implicitly enables TUI mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)