### PR TITLE
docs: fix README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Render markdown on the CLI, with _pizzazz_!
 Glow is a terminal based markdown reader designed from the ground up to bring
 out the beauty—and power—of the CLI.
 
-Use it to discover markdown files, read documentation directly on the command
+Use it to discover markdown files and read documentation directly on the command
 line. Glow will find local markdown files in subdirectories or a local
 Git repository.
 


### PR DESCRIPTION
## Summary
- Fix a comma splice in the README description.

## Related issue
- N/A (doc wording fix)

## Guideline alignment
- https://github.com/charmbracelet/glow/contribute

## Validation/testing
- Not run (docs change only)
