### PR TITLE
Fix TUI not wrapping long lines on initial render

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -95,6 +95,9 @@ type commonModel struct {
 	cwd    string
 	width  int
 	height int
+
+	// pendingBody holds markdown content to render once the window size is known.
+	pendingBody *string
 }
 
 type model struct {
@@ -196,7 +199,7 @@ func (m model) Init() tea.Cmd {
 			return func() tea.Msg { return errMsg{err} }
 		}
 		body := string(utils.RemoveFrontmatter(content))
-		cmds = append(cmds, renderWithGlamour(m.pager, body))
+		m.common.pendingBody = &body
 	}
 
 	return tea.Batch(cmds...)
@@ -266,6 +269,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.common.height = msg.Height
 		m.stash.setSize(msg.Width, msg.Height)
 		m.pager.setSize(msg.Width, msg.Height)
+		if m.common.pendingBody != nil {
+			m.pager.currentDocument.Body = *m.common.pendingBody
+			m.common.pendingBody = nil
+		}
 
 	case initLocalFileSearchMsg:
 		m.localFileFinder = msg.ch


### PR DESCRIPTION
## Summary

- When opening a markdown file with `-t` (TUI mode), long lines were not wrapped until pressing `r` to refresh
- Root cause: `Init()` called `renderWithGlamour()` before `WindowSizeMsg` arrived, so glamour rendered with `WithWordWrap(0)`
- Fix defers rendering by storing the markdown body until the first `WindowSizeMsg` sets the viewport dimensions, then lets the pager's existing resize handler render with the correct width

## Test plan

- [ ] Open a markdown file with long lines using `glow -t file.md` and verify lines wrap correctly on first render
- [ ] Resize the terminal window and verify content re-wraps correctly
- [ ] Press `r` to refresh and verify it still works
- [ ] Pipe content via stdin (`cat file.md | glow -t`) and verify it renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)