### PR TITLE
Fix: Respect config file width values including width: 0

### DIFF
--- a/main.go
+++ b/main.go
@@ -190,7 +190,7 @@ func validateOptions(cmd *cobra.Command) error {
 	}
 
 	// Detect terminal width
-	if !cmd.Flags().Changed("width") { //nolint:nestif
+	if !cmd.Flags().Changed("width") && !viper.IsSet("width") { //nolint:nestif
 		if isTerminal && width == 0 {
 			w, _, err := term.GetSize(int(os.Stdout.Fd()))
 			if err == nil {


### PR DESCRIPTION
## Problem

The `width` setting in `glow.yml` is being ignored. When users set `width: 0` to disable word wrapping, glow overrides it with auto-detected terminal width or defaults to 80. This forces users to pass `-w 0` on every command invocation.

### Current vs Expected Behavior

| Input | Expected | Actual |
|-------|----------|--------|
| `glow -w 0` | No wrapping | No wrapping (works) |
| `width: 0` in glow.yml | No wrapping | 80 or auto-detected (broken) |
| `width: 100` in glow.yml | 100 chars | 80 or auto-detected (broken) |

## Root Cause

The `validateOptions()` function checks if the CLI flag was set, but not if the config file specified a value:

```go
if !cmd.Flags().Changed("width") {
    // Runs auto-detection even when config file has width: 0
    if width == 0 {
        width = 80  // Overrides user's config
    }
}
```

This causes auto-detection to run and override explicit config file values.

## Solution

Add one condition to skip auto-detection when config file sets width:

```diff
-if !cmd.Flags().Changed("width") { //nolint:nestif
+if !cmd.Flags().Changed("width") && !viper.IsSet("width") { //nolint:nestif
```

The `viper.IsSet("width")` check returns `true` when the key exists in the config file (even if set to `0`), allowing us to distinguish between "user set it to 0" vs "uninitialized default of 0".

## Why This Is Minimal

**Single line change** - only adds `&& !viper.IsSet("width")` to existing condition.

**Preserves all functionality**:
- Auto-detection still works when nothing configured
- CLI flag remains highest priority  
- Terminal width capping at 120 unchanged
- Default fallback to 80 unchanged

**No breaking changes** - users relying on auto-detection or CLI flags see no difference.

## Correct Priority After Fix

1. CLI flag (highest)
2. Config file
3. Auto-detection (terminal width, capped at 120)
4. Default (80)

## Test Scenarios

| Scenario | Result |
|----------|--------|
| `glow -w 0 file.md` | No wrapping |
| `width: 0` in config | No wrapping |
| `width: 150` in config | 150 chars (no capping) |
| Nothing configured, 80-col terminal | 80 (auto-detected) |
| Nothing configured, 200-col terminal | 120 (auto-detected, capped) |
| Nothing configured, no terminal | 80 (default) |
| `-w 50` with `width: 100` in config | 50 (CLI wins) |