### PR TITLE
docs: fix typo in stash help comment

### DIFF
--- a/ui/stashhelp.go
+++ b/ui/stashhelp.go
@@ -8,7 +8,7 @@ import (
 )
 
 // helpEntry is a entry in a help menu containing values for a keystroke and
-// it's associated action.
+// its associated action.
 type helpEntry struct{ key, val string }
 
 // helpColumn is a group of helpEntries which will be rendered into a column.


### PR DESCRIPTION
## Summary

- Fix the `it's` typo in the stash help comment.

## Related issue

- N/A

## Guideline alignment

- One-file comment-only fix on `master`.

## Validation/testing

- Not run locally; comment-only change.
