### PR TITLE
fix: handle PAGER paths with spaces on Windows

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/caarlos0/env/v11"
@@ -319,12 +320,16 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 			pagerCmd = "less -r"
 		}
 
-		pa := strings.Split(pagerCmd, " ")
-		c := exec.Command(pa[0], pa[1:]...) //nolint:gosec
+		var c *exec.Cmd
+		if runtime.GOOS == "windows" {
+			c = exec.Command("cmd", "/c", pagerCmd) //nolint:gosec
+		} else {
+			c = exec.Command("sh", "-c", pagerCmd) //nolint:gosec
+		}
 		c.Stdin = strings.NewReader(out)
 		c.Stdout = os.Stdout
 		if err := c.Run(); err != nil {
-			return fmt.Errorf("unable to run command: %w", err)
+			return fmt.Errorf("unable to run pager command: %w", err)
 		}
 		return nil
 	case tui || cmd.Flags().Changed("tui"):


### PR DESCRIPTION
## Summary

Fixes #385

On Windows, setting `PAGER` to a path containing spaces (e.g., `"C:\Program Files\Git\usr\bin\less.exe" -r`) causes glow to fail because the command string is naively split by spaces using `strings.Split`.

## Changes

Instead of splitting the `PAGER` string by spaces and passing parts to `exec.Command`, delegate to the system shell:
- **Windows**: `cmd /c <pager command>`
- **Unix**: `sh -c <pager command>`

This matches the behavior of `git`, `man`, and other CLI tools that invoke `$PAGER`. The shell handles quoted paths, environment variable expansion, and argument parsing correctly.

## Test plan

- Set `PAGER` to a path with spaces (e.g., `"C:\Program Files\Git\usr\bin\less.exe" -r`) on Windows
- Run `glow -p README.md`
- Verify the pager opens correctly without errors
- Verify existing behavior on Unix with `PAGER="less -r"` is unchanged