### PR TITLE
[ fix ] glow wont detect config width=0 (wrap disable) in glow.yml (Debian Linux)

### DIFF
--- a/main.go
+++ b/main.go
@@ -192,7 +192,7 @@ func validateOptions(cmd *cobra.Command) error {
 	}
 
 	// Detect terminal width
-	if !cmd.Flags().Changed("width") { //nolint:nestif
+	if !cmd.Flags().Changed("width") && !viper.InConfig("width") { //nolint:nestif
 		if isTerminal && width == 0 {
 			w, _, err := term.GetSize(int(os.Stdout.Fd()))
 			if err == nil {


### PR DESCRIPTION
## Summary

- In Debian Linux, I can disable the word wrap `glow --width=0 README.md`
  - However when I set the `width: 0` in `glow.yml` config it cannot detect disabling of word wrap when I run `glow README.md`. It default to `80` width. 
  - If I set the width to > 0, it works fine, it can detect the width.

<br />
<br />
<br />


## Changes

- Add a condition to check if the width is set in `glow.yml` if the user did not explicitly set the width (e.g. `glow --width=0`). 
  - If exist, skipped the auto-detection of terminal width and capping of width. 

<br />
<br />
<br />



## Test Plan

- Set the `glow.yml` to `width: 0`.
- Run `glow README.md`.
  - It should disable the wrap. 