### PR TITLE
fix: handle UTF-16 LE/BE encoded files with BOM

### DIFF
--- a/main.go
+++ b/main.go
@@ -278,6 +278,7 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 		return fmt.Errorf("unable to read from reader: %w", err)
 	}
 
+	b = utils.ToUTF8(b)
 	b = utils.RemoveFrontmatter(b)
 
 	// render

--- a/ui/stash.go
+++ b/ui/stash.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/glow/v2/utils"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/log"
 	"github.com/muesli/reflow/ansi"
@@ -860,7 +861,7 @@ func loadLocalMarkdown(md *markdown) tea.Cmd {
 			log.Debug("error reading local file", "error", err)
 			return errMsg{err}
 		}
-		md.Body = string(data)
+		md.Body = string(utils.ToUTF8(data))
 		return fetchedMarkdownMsg(md)
 	}
 }

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -195,6 +195,7 @@ func (m model) Init() tea.Cmd {
 			log.Error("unable to read file", "file", m.common.cfg.Path, "error", err)
 			return func() tea.Msg { return errMsg{err} }
 		}
+		content = utils.ToUTF8(content)
 		body := string(utils.RemoveFrontmatter(content))
 		cmds = append(cmds, renderWithGlamour(m.pager, body))
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,6 +2,7 @@
 package utils
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -12,7 +13,37 @@ import (
 	"github.com/charmbracelet/glamour/styles"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/mitchellh/go-homedir"
+	"golang.org/x/text/encoding/unicode"
 )
+
+var (
+	utf8BOM    = []byte{0xEF, 0xBB, 0xBF}
+	utf16LEBOM = []byte{0xFF, 0xFE}
+	utf16BEBOM = []byte{0xFE, 0xFF}
+)
+
+// ToUTF8 converts UTF-16 LE/BE encoded bytes (detected via BOM) to UTF-8.
+// If the input is already UTF-8 (with or without BOM), it is returned as-is
+// (with the BOM stripped if present).
+func ToUTF8(b []byte) []byte {
+	switch {
+	case bytes.HasPrefix(b, utf8BOM):
+		return b[len(utf8BOM):]
+	case bytes.HasPrefix(b, utf16LEBOM):
+		dec := unicode.UTF16(unicode.LittleEndian, unicode.ExpectBOM).NewDecoder()
+		out, err := dec.Bytes(b)
+		if err == nil {
+			return out
+		}
+	case bytes.HasPrefix(b, utf16BEBOM):
+		dec := unicode.UTF16(unicode.BigEndian, unicode.ExpectBOM).NewDecoder()
+		out, err := dec.Bytes(b)
+		if err == nil {
+			return out
+		}
+	}
+	return b
+}
 
 // RemoveFrontmatter removes the front matter header of a markdown file.
 func RemoveFrontmatter(content []byte) []byte {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,82 @@
+package utils
+
+import (
+	"bytes"
+	"testing"
+
+	"golang.org/x/text/encoding/unicode"
+)
+
+func TestToUTF8_PlainUTF8(t *testing.T) {
+	input := []byte("# Hello, World!\n")
+	got := ToUTF8(input)
+	if !bytes.Equal(got, input) {
+		t.Errorf("plain UTF-8 should pass through unchanged\ngot:  %q\nwant: %q", got, input)
+	}
+}
+
+func TestToUTF8_UTF8BOM(t *testing.T) {
+	input := append([]byte{0xEF, 0xBB, 0xBF}, []byte("# Hello\n")...)
+	got := ToUTF8(input)
+	want := []byte("# Hello\n")
+	if !bytes.Equal(got, want) {
+		t.Errorf("UTF-8 BOM should be stripped\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestToUTF8_UTF16LE(t *testing.T) {
+	text := "# Hello\n"
+	enc := unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewEncoder()
+	encoded, err := enc.Bytes([]byte(text))
+	if err != nil {
+		t.Fatalf("failed to encode test input: %v", err)
+	}
+
+	got := ToUTF8(encoded)
+	if !bytes.Equal(got, []byte(text)) {
+		t.Errorf("UTF-16 LE with BOM should be converted to UTF-8\ngot:  %q\nwant: %q", got, text)
+	}
+}
+
+func TestToUTF8_UTF16BE(t *testing.T) {
+	text := "# Hello\n"
+	enc := unicode.UTF16(unicode.BigEndian, unicode.UseBOM).NewEncoder()
+	encoded, err := enc.Bytes([]byte(text))
+	if err != nil {
+		t.Fatalf("failed to encode test input: %v", err)
+	}
+
+	got := ToUTF8(encoded)
+	if !bytes.Equal(got, []byte(text)) {
+		t.Errorf("UTF-16 BE with BOM should be converted to UTF-8\ngot:  %q\nwant: %q", got, text)
+	}
+}
+
+func TestToUTF8_Empty(t *testing.T) {
+	got := ToUTF8([]byte{})
+	if len(got) != 0 {
+		t.Errorf("empty input should return empty output, got: %q", got)
+	}
+}
+
+func TestToUTF8_Nil(t *testing.T) {
+	got := ToUTF8(nil)
+	if got != nil {
+		t.Errorf("nil input should return nil, got: %q", got)
+	}
+}
+
+func TestToUTF8_UTF16LEWithMultibyteChars(t *testing.T) {
+	// Test UTF-16 LE with non-ASCII characters (e.g. "# Héllo\n")
+	text := "# H\u00e9llo\n"
+	enc := unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewEncoder()
+	encoded, err := enc.Bytes([]byte(text))
+	if err != nil {
+		t.Fatalf("failed to encode test input: %v", err)
+	}
+
+	got := ToUTF8(encoded)
+	if !bytes.Equal(got, []byte(text)) {
+		t.Errorf("UTF-16 LE with multibyte chars should be converted correctly\ngot:  %q\nwant: %q", got, text)
+	}
+}


### PR DESCRIPTION
Fixes #513

## Problem

UTF-16 LE/BE encoded markdown files (common when files are saved by Windows editors or converted from other formats) render as mostly blank content because the raw UTF-16 bytes are passed directly to the markdown renderer.

## Fix

Detect UTF-16 byte order marks and convert file content to UTF-8 before rendering. The conversion is applied in all three file-reading paths:

- CLI mode (`executeCLI`)
- TUI file view (`ui.Init`)
- Stash file loading (`loadLocalMarkdown`)

A `ToUTF8` utility function handles BOM detection and conversion:
- **UTF-16 LE BOM** (`FF FE`): decoded via `golang.org/x/text/encoding/unicode`
- **UTF-16 BE BOM** (`FE FF`): decoded via `golang.org/x/text/encoding/unicode`
- **UTF-8 BOM** (`EF BB BF`): stripped
- **No BOM / plain UTF-8**: passed through unchanged
- **Decode failure**: falls back to original bytes

`golang.org/x/text` is already a dependency (v0.32.0), so no new dependencies are introduced.

## Before

```
$ glow utf16le-readme.md
(mostly blank output)
```

## After

```
$ glow utf16le-readme.md

  # Hello World

  This is a test.
```

## Validation

- `go test ./...` — all pass (7 new tests for `ToUTF8`)
- `go vet ./...` — clean
- Manual test with UTF-16 LE and BE files with BOM