### PR TITLE
chore(ui): remove deprecated Bubble Tea viewport APIs

### DIFF
--- a/ui/pager.go
+++ b/ui/pager.go
@@ -109,7 +109,6 @@ func newPagerModel(common *commonModel) pagerModel {
 	// Init viewport
 	vp := viewport.New(0, 0)
 	vp.YPosition = 0
-	vp.HighPerformanceRendering = config.HighPerformancePager
 
 	m := pagerModel{
 		common:   common,
@@ -194,26 +193,14 @@ func (m pagerModel) update(msg tea.Msg) (pagerModel, tea.Cmd) {
 			}
 		case "home", "g":
 			m.viewport.GotoTop()
-			if m.viewport.HighPerformanceRendering {
-				cmds = append(cmds, viewport.Sync(m.viewport))
-			}
 		case "end", "G":
 			m.viewport.GotoBottom()
-			if m.viewport.HighPerformanceRendering {
-				cmds = append(cmds, viewport.Sync(m.viewport))
-			}
 
 		case "d":
-			m.viewport.HalfViewDown()
-			if m.viewport.HighPerformanceRendering {
-				cmds = append(cmds, viewport.Sync(m.viewport))
-			}
+			m.viewport.HalfPageDown()
 
 		case "u":
-			m.viewport.HalfViewUp()
-			if m.viewport.HighPerformanceRendering {
-				cmds = append(cmds, viewport.Sync(m.viewport))
-			}
+			m.viewport.HalfPageUp()
 
 		case "e":
 			lineno := int(math.RoundToEven(float64(m.viewport.TotalLineCount()) * m.viewport.ScrollPercent()))
@@ -239,9 +226,6 @@ func (m pagerModel) update(msg tea.Msg) (pagerModel, tea.Cmd) {
 
 		case "?":
 			m.toggleHelp()
-			if m.viewport.HighPerformanceRendering {
-				cmds = append(cmds, viewport.Sync(m.viewport))
-			}
 		}
 
 	// Glow has rendered the content
@@ -249,9 +233,6 @@ func (m pagerModel) update(msg tea.Msg) (pagerModel, tea.Cmd) {
 		log.Info("content rendered", "state", m.state)
 
 		m.setContent(string(msg))
-		if m.viewport.HighPerformanceRendering {
-			cmds = append(cmds, viewport.Sync(m.viewport))
-		}
 		cmds = append(cmds, m.watchFile)
 
 	// The file was changed on disk and we're reloading it

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -120,10 +120,6 @@ func (m *model) unloadDocument() []tea.Cmd {
 	m.pager.showHelp = false
 
 	var batch []tea.Cmd
-	if m.pager.viewport.HighPerformanceRendering {
-		batch = append(batch, tea.ClearScrollArea) //nolint:staticcheck
-	}
-
 	if !m.stash.shouldSpin() {
 		batch = append(batch, m.stash.spinner.Tick)
 	}


### PR DESCRIPTION
bubbles v0.21 marked HighPerformanceRendering, viewport.Sync, Half{View}{Up,Down}, and tea.ClearScrollArea as deprecated; v2 removes HighPerformanceRendering entirely. This commit drops the dead high-performance-rendering branches from the pager key handler and contentRenderedMsg, unload's ClearScrollArea path, and renames Half{View}{Up,Down} to Half{Page}{Up,Down}.

Config.HighPerformancePager stays for env-parsing compatibility so users with GLOW_HIGH_PERFORMANCE_PAGER set still boot cleanly; the field is simply no longer consumed. Rendering now relies on Bubble Tea's default renderer, which is what the deprecation notices recommended.
