### PR TITLE
fix: ensure closing fence in WrapCodeBlock is on its own line

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -42,6 +42,9 @@ func ExpandPath(path string) string {
 
 // WrapCodeBlock wraps a string in a code block with the given language.
 func WrapCodeBlock(s, language string) string {
+	if !strings.HasSuffix(s, "\n") {
+		s += "\n"
+	}
 	return "```" + language + "\n" + s + "```"
 }
 


### PR DESCRIPTION
## Summary

`WrapCodeBlock` glued the closing ``` ``` ``` directly onto the last line of the content. When the input didn't end with a newline (e.g. a source file without a trailing newline), Markdown renderers never saw the closing fence on its own line and the code block stayed open through the rest of the document.

This appends a newline to the content only when one isn't already present, so inputs that already terminate with `\n` don't gain a spurious blank line before the fence.

Affects both call sites that wrap raw file contents:
- `main.go:308`
- `ui/pager.go:449`

## Test plan

- [x] `go build ./...` and `go vet ./...` pass
- [ ] Render a code-only file with no trailing newline via `glow path/to/file.go` and confirm the fenced block closes correctly
- [ ] Render a code-only file *with* a trailing newline and confirm there is no extra blank line before the closing fence

🤖 Generated with [Claude Code](https://claude.com/claude-code)