### PR TITLE
TUI: correct redraw on resize and smart word-wrap at terminal width

### DIFF
--- a/main.go
+++ b/main.go
@@ -199,9 +199,7 @@ func validateOptions(cmd *cobra.Command) error {
 				width = uint(w) //nolint:gosec
 			}
 
-			if width > 120 {
-				width = 120
-			}
+
 		}
 		if width == 0 {
 			width = 80

--- a/ui/pager.go
+++ b/ui/pager.go
@@ -78,8 +78,11 @@ var (
 )
 
 type (
-	contentRenderedMsg string
-	reloadMsg          struct{}
+	contentRenderedMsg struct {
+		content string
+		body    string // original markdown body, cached for re-render on resize
+	}
+	reloadMsg struct{}
 )
 
 type pagerState int
@@ -248,7 +251,10 @@ func (m pagerModel) update(msg tea.Msg) (pagerModel, tea.Cmd) {
 	case contentRenderedMsg:
 		log.Info("content rendered", "state", m.state)
 
-		m.setContent(string(msg))
+		if msg.body != "" {
+			m.currentDocument.Body = msg.body
+		}
+		m.setContent(msg.content)
 		if m.viewport.HighPerformanceRendering {
 			cmds = append(cmds, viewport.Sync(m.viewport))
 		}
@@ -267,7 +273,12 @@ func (m pagerModel) update(msg tea.Msg) (pagerModel, tea.Cmd) {
 	// We've received terminal dimensions, either for the first time or
 	// after a resize
 	case tea.WindowSizeMsg:
-		return m, renderWithGlamour(m, m.currentDocument.Body)
+		if m.viewport.HighPerformanceRendering {
+			cmds = append(cmds, viewport.Sync(m.viewport))
+		}
+		if m.currentDocument.Body != "" {
+			cmds = append(cmds, renderWithGlamour(m, m.currentDocument.Body))
+		}
 
 	case statusMessageTimeoutMsg:
 		m.state = pagerStateBrowse
@@ -414,7 +425,7 @@ func renderWithGlamour(m pagerModel, md string) tea.Cmd {
 			log.Error("error rendering with Glamour", "error", err)
 			return errMsg{err}
 		}
-		return contentRenderedMsg(s)
+		return contentRenderedMsg{content: s, body: md}
 	}
 }
 

--- a/ui/pager.go
+++ b/ui/pager.go
@@ -438,7 +438,11 @@ func glamourRender(m pagerModel, markdown string) (string, error) {
 	}
 
 	isCode := !utils.IsMarkdownFile(m.currentDocument.Note)
-	width := max(0, min(int(m.common.cfg.GlamourMaxWidth), m.viewport.Width)) //nolint:gosec
+	viewportWidth := m.viewport.Width
+	if viewportWidth == 0 {
+		viewportWidth = int(m.common.cfg.GlamourMaxWidth) //nolint:gosec
+	}
+	width := max(0, viewportWidth)
 	if isCode {
 		width = 0
 	}
@@ -478,7 +482,8 @@ func glamourRender(m pagerModel, markdown string) (string, error) {
 			content.WriteString(lineNumberStyle(fmt.Sprintf("%"+fmt.Sprint(lineNumberWidth)+"d", i+1)))
 			content.WriteString(trunc(s))
 		} else {
-			content.WriteString(s)
+			wrapped := softWrapLine(s, m.viewport.Width, 10)
+			content.WriteString(wrapped)
 		}
 
 		// don't add an artificial newline after the last split
@@ -488,6 +493,132 @@ func glamourRender(m pagerModel, markdown string) (string, error) {
 	}
 
 	return content.String(), nil
+}
+
+// softWrapLine wraps a single line (which may contain ANSI escape sequences)
+// at maxWidth. When the limit is reached it searches backwards up to threshold
+// visible characters for a whitespace or punctuation character and breaks after
+// it. Leading whitespace on continuation lines is stripped.
+func softWrapLine(line string, maxWidth, threshold int) string {
+	if maxWidth <= 0 || ansi.PrintableRuneWidth(line) <= maxWidth {
+		return line
+	}
+
+	type segment struct {
+		raw     string
+		visible int // 0 for ANSI escape sequences
+	}
+
+	// Parse into segments: ANSI escapes (visible=0) and individual runes.
+	segments := make([]segment, 0, len(line))
+	for i := 0; i < len(line); {
+		if line[i] == '\x1b' && i+1 < len(line) && line[i+1] == '[' {
+			j := i + 2
+			for j < len(line) && !((line[j] >= 'A' && line[j] <= 'Z') || (line[j] >= 'a' && line[j] <= 'z')) {
+				j++
+			}
+			if j < len(line) {
+				j++
+			}
+			segments = append(segments, segment{raw: line[i:j], visible: 0})
+			i = j
+			continue
+		}
+		var r rune
+		var size int
+		for _, ch := range line[i:] {
+			r = ch
+			size = len(string(ch))
+			break
+		}
+		segments = append(segments, segment{raw: line[i : i+size], visible: runewidth.RuneWidth(r)})
+		i += size
+	}
+
+	isBreakable := func(s string) bool {
+		if s == " " || s == "\t" {
+			return true
+		}
+		r := rune(s[0])
+		return r == '-' || r == '/' || r == '_' || r == '.' || r == ',' || r == ';' || r == ':'
+	}
+
+	// visCols records, for each visible segment, its segments-index and the
+	// cumulative visible column after it (relative to the current line start).
+	type segCol struct {
+		segIdx int
+		col    int
+	}
+
+	var result strings.Builder
+	lineStart := 0
+	col := 0
+	visCols := make([]segCol, 0, maxWidth)
+
+	for idx := 0; idx < len(segments); idx++ {
+		seg := segments[idx]
+		if seg.visible == 0 {
+			continue
+		}
+		col += seg.visible
+		visCols = append(visCols, segCol{segIdx: idx, col: col})
+
+		if col < maxWidth {
+			continue
+		}
+
+		// First: search backwards within threshold of maxWidth for a breakable
+		// character (preferred break point close to the margin).
+		breakAt := -1
+		nextStart := -1
+		for b := len(visCols) - 1; b >= 0; b-- {
+			if visCols[b].col < maxWidth-threshold {
+				break
+			}
+			si := visCols[b].segIdx
+			if isBreakable(segments[si].raw) {
+				breakAt = si + 1
+				nextStart = si + 1
+				break
+			}
+		}
+		// Fallback: no breakpoint in threshold window — search further back for
+		// any whitespace to avoid splitting mid-word.
+		if breakAt < 0 {
+			for b := len(visCols) - 1; b >= 0; b-- {
+				si := visCols[b].segIdx
+				if segments[si].raw == " " || segments[si].raw == "\t" {
+					breakAt = si + 1
+					nextStart = si + 1
+					break
+				}
+			}
+		}
+		// Last resort: hard break before the current segment.
+		if breakAt < 0 {
+			breakAt = idx
+			nextStart = idx
+		}
+
+		for _, s := range segments[lineStart:breakAt] {
+			result.WriteString(s.raw)
+		}
+		result.WriteByte('\n')
+
+		// Strip leading whitespace on the continuation line.
+		for nextStart < len(segments) && (segments[nextStart].raw == " " || segments[nextStart].raw == "\t") {
+			nextStart++
+		}
+		lineStart = nextStart
+		idx = lineStart - 1 // loop will increment
+		col = 0
+		visCols = visCols[:0]
+	}
+
+	for _, seg := range segments[lineStart:] {
+		result.WriteString(seg.raw)
+	}
+	return result.String()
 }
 
 func (m *pagerModel) initWatcher() {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -190,13 +190,7 @@ func (m model) Init() tea.Cmd {
 	case stateShowStash:
 		cmds = append(cmds, findLocalFiles(*m.common))
 	case stateShowDocument:
-		content, err := os.ReadFile(m.common.cfg.Path)
-		if err != nil {
-			log.Error("unable to read file", "file", m.common.cfg.Path, "error", err)
-			return func() tea.Msg { return errMsg{err} }
-		}
-		body := string(utils.RemoveFrontmatter(content))
-		cmds = append(cmds, renderWithGlamour(m.pager, body))
+		cmds = append(cmds, loadLocalMarkdown(&m.pager.currentDocument))
 	}
 
 	return tea.Batch(cmds...)


### PR DESCRIPTION
- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

## Description

Two related TUI rendering fixes for the pager:

### Fix 1: Correct redraw on terminal resize

Previously, resizing the terminal could result in a blank or stale pager because:
- `contentRenderedMsg` was a plain `string` type, so the original markdown body was lost after the initial render.
- On `WindowSizeMsg`, the code returned early when the body was empty and did not call `viewport.Sync()` in high-performance mode.

**Changes:**
- `contentRenderedMsg` is now a struct carrying both the rendered `content` string and the original `body` (markdown source), which is cached back onto `currentDocument.Body` after rendering.
- On `WindowSizeMsg`, `viewport.Sync()` is called immediately (high-performance mode) and the pager re-renders with the cached body using the new terminal width.
- Initial file render is deferred from `Init()` to after the first `WindowSizeMsg` via `loadLocalMarkdown`, so glamour receives the correct viewport width instead of 0.

### Fix 2: Smart word-wrap at terminal width

Previously, glamour rendering was capped at a hardcoded `GlamourMaxWidth` (120 chars), meaning long lines on wide terminals would overflow the viewport and wrap mid-word by the terminal emulator.

**Changes:**
- Removed the `min(GlamourMaxWidth, viewport.Width)` cap; glamour now renders to the full `viewport.Width`, which is already dynamic.
- `GlamourMaxWidth` is used as a fallback only when `viewport.Width` is 0 (before the first `WindowSizeMsg`).
- Added `softWrapLine`: an ANSI-aware post-render wrapper that searches backwards up to 10 visible characters from the margin for a whitespace or punctuation break point, with a full-line whitespace fallback and a hard-break last resort — preventing mid-word splits regardless of terminal width.

## Steps to reproduce / before & after

**Resize regression:**
1. Open a markdown file with `glow somefile.md`
2. Resize the terminal window
3. **Before:** pager goes blank or retains stale content at the old width
4. **After:** pager re-renders correctly at the new width

**Word-wrap:**
1. Open a markdown file containing long lines on a terminal wider than 120 columns
2. **Before:** lines overflow and are wrapped mid-word by the terminal
3. **After:** lines wrap cleanly at word/punctuation boundaries within the terminal width
