### PR TITLE
fix: reflow TUI pager content on terminal resize

### DIFF
--- a/ui/pager.go
+++ b/ui/pager.go
@@ -265,8 +265,13 @@ func (m pagerModel) update(msg tea.Msg) (pagerModel, tea.Cmd) {
 		return m, loadLocalMarkdown(&m.currentDocument)
 
 	// We've received terminal dimensions, either for the first time or
-	// after a resize
+	// after a resize (SIGWINCH). Skip re-rendering until the document body
+	// has been loaded, otherwise the in-flight load would race with an empty
+	// re-render that clears the viewport.
 	case tea.WindowSizeMsg:
+		if m.currentDocument.Body == "" {
+			return m, nil
+		}
 		return m, renderWithGlamour(m, m.currentDocument.Body)
 
 	case statusMessageTimeoutMsg:

--- a/ui/resize_test.go
+++ b/ui/resize_test.go
@@ -1,0 +1,140 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// drainCmd runs a tea.Cmd to completion and returns every concrete message it
+// produces, recursing into tea.BatchMsg. Long-blocking subscription commands
+// (e.g. spinner ticks, fsnotify) are skipped via a short deadline so tests
+// don't hang.
+func drainCmd(t *testing.T, cmd tea.Cmd) []tea.Msg {
+	t.Helper()
+	if cmd == nil {
+		return nil
+	}
+	out := make(chan tea.Msg, 1)
+	go func() {
+		defer func() { _ = recover() }()
+		out <- cmd()
+	}()
+	select {
+	case msg := <-out:
+		if msg == nil {
+			return nil
+		}
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			var msgs []tea.Msg
+			for _, c := range batch {
+				msgs = append(msgs, drainCmd(t, c)...)
+			}
+			return msgs
+		}
+		return []tea.Msg{msg}
+	case <-time.After(200 * time.Millisecond):
+		return nil
+	}
+}
+
+// runUpdate feeds a single message into Update and drains every resulting
+// command, cascading the produced messages back through Update. Returns the
+// final model after the cascade settles.
+func runUpdate(t *testing.T, m tea.Model, msg tea.Msg) tea.Model {
+	t.Helper()
+	mm, cmd := m.Update(msg)
+	for _, follow := range drainCmd(t, cmd) {
+		mm = runUpdate(t, mm, follow)
+	}
+	return mm
+}
+
+// TestResizeReflowsContent confirms that, after a WindowSizeMsg, the pager
+// re-renders the current document at the new width rather than leaving the
+// viewport empty. Regression test for the SIGWINCH/resize bug where
+// currentDocument.Body was never populated for files opened by path.
+func TestResizeReflowsContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.md")
+	body := "# Hello\n\nThis is a paragraph with enough words to wrap nicely across multiple lines so we can observe reflow at different widths.\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Config{
+		Path:            path,
+		GlamourEnabled:  true,
+		GlamourStyle:    "notty",
+		GlamourMaxWidth: 120,
+	}
+	config = cfg
+
+	m := newModel(cfg, "")
+	for _, msg := range drainCmd(t, m.Init()) {
+		m = runUpdate(t, m, msg)
+	}
+
+	mm := m.(model)
+	if mm.pager.currentDocument.Body == "" {
+		t.Fatalf("after Init, currentDocument.Body should be populated; got empty")
+	}
+	if !strings.Contains(mm.pager.currentDocument.Body, "Hello") {
+		t.Fatalf("currentDocument.Body missing source content; got %q", mm.pager.currentDocument.Body)
+	}
+
+	m = runUpdate(t, m, tea.WindowSizeMsg{Width: 80, Height: 24})
+	mm = m.(model)
+	narrowView := mm.View()
+	if narrowView == "" || !strings.Contains(narrowView, "Hello") {
+		t.Fatalf("after WindowSizeMsg{80,24}, view should contain rendered content; got %q", narrowView)
+	}
+
+	m = runUpdate(t, m, tea.WindowSizeMsg{Width: 120, Height: 24})
+	mm = m.(model)
+	wideView := mm.View()
+	if wideView == "" || !strings.Contains(wideView, "Hello") {
+		t.Fatalf("after WindowSizeMsg{120,24}, view should contain rendered content; got %q", wideView)
+	}
+
+	if narrowView == wideView {
+		t.Fatalf("view unchanged across resize; resize did not reflow content")
+	}
+}
+
+// TestResizeStripsFrontmatterOnce confirms that loaded documents have their
+// frontmatter stripped exactly once and stored on currentDocument.Body, so
+// resize re-renders don't expose the frontmatter.
+func TestResizeStripsFrontmatterOnce(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.md")
+	body := "---\ntitle: Test\n---\n\n# Hello\n\nBody text.\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Config{
+		Path:            path,
+		GlamourEnabled:  true,
+		GlamourStyle:    "notty",
+		GlamourMaxWidth: 120,
+	}
+	config = cfg
+
+	m := newModel(cfg, "")
+	for _, msg := range drainCmd(t, m.Init()) {
+		m = runUpdate(t, m, msg)
+	}
+	mm := m.(model)
+
+	if strings.Contains(mm.pager.currentDocument.Body, "title: Test") {
+		t.Fatalf("currentDocument.Body still contains frontmatter: %q", mm.pager.currentDocument.Body)
+	}
+	if !strings.Contains(mm.pager.currentDocument.Body, "Hello") {
+		t.Fatalf("currentDocument.Body missing body content; got %q", mm.pager.currentDocument.Body)
+	}
+}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -190,13 +190,15 @@ func (m model) Init() tea.Cmd {
 	case stateShowStash:
 		cmds = append(cmds, findLocalFiles(*m.common))
 	case stateShowDocument:
-		content, err := os.ReadFile(m.common.cfg.Path)
-		if err != nil {
-			log.Error("unable to read file", "file", m.common.cfg.Path, "error", err)
-			return func() tea.Msg { return errMsg{err} }
+		// If we have a local path, load via the shared loadLocalMarkdown
+		// command so currentDocument.Body is populated on the model. This is
+		// required for the WindowSizeMsg handler to re-render the document at
+		// the new width when the terminal is resized (SIGWINCH).
+		if m.pager.currentDocument.localPath != "" {
+			cmds = append(cmds, loadLocalMarkdown(&m.pager.currentDocument))
+		} else if m.pager.currentDocument.Body != "" {
+			cmds = append(cmds, renderWithGlamour(m.pager, m.pager.currentDocument.Body))
 		}
-		body := string(utils.RemoveFrontmatter(content))
-		cmds = append(cmds, renderWithGlamour(m.pager, body))
 	}
 
 	return tea.Batch(cmds...)
@@ -273,10 +275,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, findNextLocalFile(m))
 
 	case fetchedMarkdownMsg:
-		// We've loaded a markdown file's contents for rendering
+		// We've loaded a markdown file's contents for rendering. Strip the
+		// frontmatter once here and store the renderable body on the document
+		// so resize re-renders (WindowSizeMsg) use the same content.
 		m.pager.currentDocument = *msg
-		body := string(utils.RemoveFrontmatter([]byte(msg.Body)))
-		cmds = append(cmds, renderWithGlamour(m.pager, body))
+		m.pager.currentDocument.Body = string(utils.RemoveFrontmatter([]byte(msg.Body)))
+		cmds = append(cmds, renderWithGlamour(m.pager, m.pager.currentDocument.Body))
 
 	case contentRenderedMsg:
 		m.state = stateShowDocument


### PR DESCRIPTION
## Summary

Fixes #787 — in TUI mode, resizing the terminal while a markdown file is open either clears the viewport (files opened by path) or exposes the YAML frontmatter (files opened from the stash). The pager's `WindowSizeMsg` handler re-rendered `m.currentDocument.Body`, but `Body` was inconsistent across entry paths:

- `Init()` read the file into a local variable and never wrote it back to `currentDocument.Body`, so direct-file opens left `Body` empty → resize re-rendered `""` and cleared the viewport.
- `fetchedMarkdownMsg` stored the raw file contents (frontmatter included) on `Body` and stripped only into a local for the initial render → resize re-rendered with frontmatter visible.

## Changes

- `ui/ui.go` — `Init()` now uses `loadLocalMarkdown` for local paths, so `currentDocument.Body` is populated on the model via the same `fetchedMarkdownMsg` flow used by the reload key (`r`) and stash selection. The inline `os.ReadFile` path is gone.
- `ui/ui.go` — the `fetchedMarkdownMsg` handler strips frontmatter once and writes the renderable body back to `currentDocument.Body`, so resize re-renders use the same content the user is seeing.
- `ui/pager.go` — `WindowSizeMsg` handler guards against empty `Body` to prevent an initial resize-before-load race from clearing the viewport.
- `ui/resize_test.go` — regression tests that drive the bubbletea message cascade end-to-end (Init → load → fetched → render → resize → re-render) and assert content reflows across two different widths. The tests fail on `master` and pass with this change.

## Behavior change

The copy key (`c`) now puts the frontmatter-stripped body on the clipboard instead of the raw file. This matches what is shown on screen.

## Test plan

- [x] `go test ./...` passes (including new regression tests)
- [x] `go test ./ui/ -race` passes
- [x] `go vet ./...` clean
- [x] Manual: open `glow -t README.md`, resize terminal — content reflows at the new width.
- [x] Manual: open `glow .`, select a file with YAML frontmatter, resize — frontmatter no longer surfaces in the rendered view.