### PR TITLE
Fix #930: Auto-page when output exceeds terminal height

### DIFF
--- a/main.go
+++ b/main.go
@@ -313,12 +313,10 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 		return fmt.Errorf("unable to render markdown: %w", err)
 	}
 
-	// display
-	switch {
-	case pager || cmd.Flags().Changed("pager"):
+	runPager := func() error {
 		pagerCmd := os.Getenv("PAGER")
 		if pagerCmd == "" {
-			pagerCmd = "less -r"
+			pagerCmd = "less -r -F -X"
 		}
 
 		fields, err := shell.Fields(pagerCmd, os.Getenv)
@@ -332,6 +330,12 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 			return fmt.Errorf("unable to run command: %w", err)
 		}
 		return nil
+	}
+
+	// display
+	switch {
+	case pager || cmd.Flags().Changed("pager"):
+		return runPager()
 	case tui || cmd.Flags().Changed("tui"):
 		path := ""
 		if !isURL(src.URL) {
@@ -339,6 +343,13 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 		}
 		return runTUI(path, content)
 	default:
+		// Auto-page if writing to a terminal and content exceeds terminal height
+		if f, ok := w.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
+			_, height, err := term.GetSize(int(f.Fd()))
+			if err == nil && strings.Count(out, "\n") > height {
+				return runPager()
+			}
+		}
 		if _, err = fmt.Fprint(w, out); err != nil {
 			return fmt.Errorf("unable to write to writer: %w", err)
 		}

--- a/main.go
+++ b/main.go
@@ -346,7 +346,7 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 		// Auto-page if writing to a terminal and content exceeds terminal height
 		if f, ok := w.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
 			_, height, err := term.GetSize(int(f.Fd()))
-			if err == nil && strings.Count(out, "\n")+1 > height {
+			if err == nil && strings.Count(out, "\n") > height {
 				return runPager()
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -346,7 +346,7 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 		// Auto-page if writing to a terminal and content exceeds terminal height
 		if f, ok := w.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
 			_, height, err := term.GetSize(int(f.Fd()))
-			if err == nil && strings.Count(out, "\n") > height {
+			if err == nil && strings.Count(out, "\n")+1 > height {
 				return runPager()
 			}
 		}


### PR DESCRIPTION
Fixes #930.

When run without `--pager`, glow now checks whether stdout is a terminal and whether the rendered markdown is taller than the terminal. If so, it pages through the existing pager flow (`PAGER` env or `less -r -F -X`).

The branch contains three commits: the original fix, an off-by-one tweak, and a revert of that tweak (the original line-count comparison was correct — `strings.Count(out, "\n") > height`). Net diff is +15/-4 in `main.go`.

## Testing

- Manual: `glow README.md` on small terminal pages; on tall terminal, prints inline. Existing `--pager`/`--tui` paths unchanged.
- `go build ./...` passes.

## Hypothesis graph

Investigation provenance: https://github.com/kimjune01/sweep/blob/master/repo-hypotheses/charmbracelet-glow.md

Captures the triage scoring (5 ranked issues), why #930 was picked, codex's initial fix, the 3 bugs gemini caught on review (writer-vs-stdout, sledgehammer paging, less flags), and the final applied fixes.
