### PR TITLE
include pager stderr in --pager failure messages

### DIFF
--- a/main.go
+++ b/main.go
@@ -328,8 +328,16 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 		c := exec.Command(fields[0], fields[1:]...) //nolint:gosec
 		c.Stdin = strings.NewReader(out)
 		c.Stdout = os.Stdout
+		// Capture stderr so we can include the pager's own complaint in
+		// our error. Without this you just get "exit status 1" from
+		// pagers like `most` that reject input they don't like (#153).
+		var stderr strings.Builder
+		c.Stderr = &stderr
 		if err := c.Run(); err != nil {
-			return fmt.Errorf("unable to run command: %w", err)
+			if msg := strings.TrimSpace(stderr.String()); msg != "" {
+				return fmt.Errorf("pager %q failed: %w: %s", fields[0], err, msg)
+			}
+			return fmt.Errorf("pager %q failed: %w", fields[0], err)
 		}
 		return nil
 	case tui || cmd.Flags().Changed("tui"):


### PR DESCRIPTION
Closes #153.

When the pager command fails (e.g. \`most\` exits non-zero on input it doesn't like), the user just sees "Error: unable to run command: exit status 1" with no clue which pager failed or why — the pager's own stderr is dropped because \`c.Stderr\` is never assigned.

Capture stderr into a buffer, name the pager binary in the error, and append the pager's complaint when there is one. \`PAGER=most glow -p\` now reports something like:

\`\`\`
pager "most" failed: exit status 1: most: Cannot ...
\`\`\`

instead of a bare "exit status 1". Same shape for the not-installed case:

\`\`\`
pager "most" failed: exec: "most": executable file not found in \$PATH
\`\`\`

Reproduced both locally (the second one against my machine which doesn't have most). Full test suite passes.