### PR TITLE
fix: expand ~ in style path from glow.yml

### DIFF
--- a/glow_test.go
+++ b/glow_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -37,5 +40,58 @@ func TestGlowFlags(t *testing.T) {
 		if !v.check() {
 			t.Errorf("Parsing flag failed: %s", v.args)
 		}
+	}
+}
+
+func TestValidateStyle(t *testing.T) {
+	// Built-in styles should pass through unchanged.
+	for _, name := range []string{"auto", "dark", "light", "notty"} {
+		got, err := validateStyle(name)
+		if err != nil {
+			t.Errorf("validateStyle(%q) returned error: %v", name, err)
+		}
+		if got != name {
+			t.Errorf("validateStyle(%q) = %q, want %q", name, got, name)
+		}
+	}
+
+	// Custom paths with a leading ~ should be expanded to the user's home
+	// directory. This is the regression covered by #713.
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("cannot determine home dir: %v", err)
+	}
+	dir := t.TempDir()
+	rel, err := filepath.Rel(home, dir)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		t.Skip("temp dir is not under the user's home directory")
+	}
+	stylePath := filepath.Join(dir, "custom.json")
+	if err := os.WriteFile(stylePath, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tildePath := "~/" + filepath.ToSlash(filepath.Join(rel, "custom.json"))
+
+	got, err := validateStyle(tildePath)
+	if err != nil {
+		t.Fatalf("validateStyle(%q) returned error: %v", tildePath, err)
+	}
+	if got == tildePath || strings.HasPrefix(got, "~") {
+		t.Errorf("validateStyle(%q) = %q, expected ~ to be expanded", tildePath, got)
+	}
+	if got != stylePath {
+		t.Errorf("validateStyle(%q) = %q, want %q", tildePath, got, stylePath)
+	}
+
+	// A missing custom style should surface an error mentioning the
+	// expanded path (not the raw ~ form), so users can see what was looked
+	// up on disk.
+	missing := "~/does-not-exist-" + filepath.Base(dir) + ".json"
+	_, err = validateStyle(missing)
+	if err == nil {
+		t.Fatalf("validateStyle(%q) returned no error", missing)
+	}
+	if strings.Contains(err.Error(), "~") {
+		t.Errorf("error message %q still contains a raw tilde", err.Error())
 	}
 }

--- a/main.go
+++ b/main.go
@@ -150,18 +150,22 @@ func sourceFromArg(arg string) (*source, error) {
 	return &source{r, u}, nil
 }
 
-// validateStyle checks if the style is a default style, if not, checks that
-// the custom style exists.
-func validateStyle(style string) error {
-	if style != "auto" && styles.DefaultStyles[style] == nil {
-		style = utils.ExpandPath(style)
-		if _, err := os.Stat(style); errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("specified style does not exist: %s", style)
-		} else if err != nil {
-			return fmt.Errorf("unable to stat file: %w", err)
-		}
+// validateStyle checks if the style is a default style, otherwise treats it
+// as a path to a custom style file and verifies it exists. Custom paths are
+// expanded (so a leading ~ becomes the user's home directory) and the
+// expanded path is returned, since the caller needs that value to load the
+// file later.
+func validateStyle(style string) (string, error) {
+	if style == "auto" || styles.DefaultStyles[style] != nil {
+		return style, nil
 	}
-	return nil
+	expanded := utils.ExpandPath(style)
+	if _, err := os.Stat(expanded); errors.Is(err, fs.ErrNotExist) {
+		return "", fmt.Errorf("specified style does not exist: %s", expanded)
+	} else if err != nil {
+		return "", fmt.Errorf("unable to stat file: %w", err)
+	}
+	return expanded, nil
 }
 
 func validateOptions(cmd *cobra.Command) error {
@@ -179,10 +183,11 @@ func validateOptions(cmd *cobra.Command) error {
 	}
 
 	// validate the glamour style
-	style = viper.GetString("style")
-	if err := validateStyle(style); err != nil {
+	resolved, err := validateStyle(viper.GetString("style"))
+	if err != nil {
 		return err
 	}
+	style = resolved
 
 	isTerminal := term.IsTerminal(int(os.Stdout.Fd()))
 	// We want to use a special no-TTY style, when stdout is not a terminal
@@ -354,8 +359,10 @@ func runTUI(path string, content string) error {
 	}
 
 	// use style set in env, or auto if unset
-	if err := validateStyle(cfg.GlamourStyle); err != nil {
+	if resolved, err := validateStyle(cfg.GlamourStyle); err != nil {
 		cfg.GlamourStyle = style
+	} else {
+		cfg.GlamourStyle = resolved
 	}
 
 	cfg.Path = path


### PR DESCRIPTION
Closes #713.

When `style:` in `glow.yml` starts with `~`, glow fails to open it:

```
$ glow README.md
Error: open ~/.config/glow/sarastyle.json: no such file or directory
```

`validateStyle` did call `utils.ExpandPath`, but only on the function-local copy of the parameter, so the expanded value never made it back to the outer `style` package var. Glamour then tried to open the literal `~/...` path.

Fix is to return the expanded path from `validateStyle` and use that at both call sites (the CLI flow in `validateOptions`, and the TUI flow in `runTUI`). Built-in style names like `auto` / `dark` / `light` are returned unchanged.

Added a `TestValidateStyle` covering the built-in pass-through, the `~`-expansion happy path, and the error message when the file is missing (the message should show the expanded path, not the raw tilde).