### PR TITLE
Use full terminal width in auto-detected wrap mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ The `-w` flag lets you set a maximum width at which the output will be wrapped:
 glow -w 60
 ```
 
+When `-w` is not provided, Glow will use your terminal's current width when possible.
+
 ### Paging
 
 CLI output can be displayed in your preferred pager with the `-p` flag. This defaults

--- a/main.go
+++ b/main.go
@@ -164,6 +164,22 @@ func validateStyle(style string) error {
 	return nil
 }
 
+func resolveWidth(isTerminal bool, configuredWidth uint, widthFlagChanged bool, getTerminalWidth func() (int, error)) uint {
+	width := configuredWidth
+	if !widthFlagChanged {
+		if isTerminal && width == 0 {
+			w, err := getTerminalWidth()
+			if err == nil && w > 0 {
+				width = uint(w) //nolint:gosec
+			}
+		}
+		if width == 0 {
+			width = 80
+		}
+	}
+	return width
+}
+
 func validateOptions(cmd *cobra.Command) error {
 	// grab config values from Viper
 	width = viper.GetUint("width")
@@ -191,22 +207,13 @@ func validateOptions(cmd *cobra.Command) error {
 		style = "notty"
 	}
 
-	// Detect terminal width
-	if !cmd.Flags().Changed("width") { //nolint:nestif
-		if isTerminal && width == 0 {
-			w, _, err := term.GetSize(int(os.Stdout.Fd()))
-			if err == nil {
-				width = uint(w) //nolint:gosec
-			}
-
-			if width > 120 {
-				width = 120
-			}
+	width = resolveWidth(isTerminal, width, cmd.Flags().Changed("width"), func() (int, error) {
+		w, _, err := term.GetSize(int(os.Stdout.Fd()))
+		if err != nil {
+			return 0, err
 		}
-		if width == 0 {
-			width = 80
-		}
-	}
+		return w, nil
+	})
 	return nil
 }
 

--- a/main_width_test.go
+++ b/main_width_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestResolveWidth(t *testing.T) {
+	tt := []struct {
+		name            string
+		isTerminal      bool
+		configuredWidth uint
+		flagChanged     bool
+		detectedWidth   int
+		detectErr       error
+		want            uint
+	}{
+		{
+			name:            "explicit width keeps configured value",
+			isTerminal:      true,
+			configuredWidth: 40,
+			flagChanged:     true,
+			detectedWidth:   180,
+			want:            40,
+		},
+		{
+			name:            "explicit zero width is preserved",
+			isTerminal:      true,
+			configuredWidth: 0,
+			flagChanged:     true,
+			detectedWidth:   180,
+			want:            0,
+		},
+		{
+			name:            "auto width uses detected terminal width",
+			isTerminal:      true,
+			configuredWidth: 0,
+			flagChanged:     false,
+			detectedWidth:   100,
+			want:            100,
+		},
+		{
+			name:            "auto width no longer caps terminal width",
+			isTerminal:      true,
+			configuredWidth: 0,
+			flagChanged:     false,
+			detectedWidth:   180,
+			want:            180,
+		},
+		{
+			name:            "auto width falls back when detection fails",
+			isTerminal:      true,
+			configuredWidth: 0,
+			flagChanged:     false,
+			detectErr:       errors.New("boom"),
+			want:            80,
+		},
+		{
+			name:            "non-tty fallback remains 80",
+			isTerminal:      false,
+			configuredWidth: 0,
+			flagChanged:     false,
+			want:            80,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveWidth(tc.isTerminal, tc.configuredWidth, tc.flagChanged, func() (int, error) {
+				return tc.detectedWidth, tc.detectErr
+			})
+
+			if got != tc.want {
+				t.Fatalf("resolveWidth() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR removes the 120-column clamp from Glow's auto-detected CLI wrap width path.

## Why

Issue #942 requests behavior equivalent to automatically using terminal width (like `-w $COLUMNS`) without requiring shell-specific variables or external commands.

Glow already had terminal width auto-detection, but the detected value was capped at 120 columns, which caused premature wrapping on wide terminals.

## What changed

1. Removed the 120-column cap in auto-detected width resolution.
2. Refactored width resolution into a small helper (`resolveWidth`) for clearer logic and testability.
3. Added table-driven tests for width resolution behavior.
4. Clarified README wording for default wrap behavior when `-w` is not provided.

## Behavior

- Explicit `-w/--width` still has highest priority.
- `-w 0` behavior is unchanged.
- Non-TTY / detection-failure fallback remains unchanged.
- No changes to long-word/hard-wrap behavior.
- No TUI layout behavior changes.

## Tests

- Added unit tests in `main_width_test.go` covering:
  - explicit width
  - explicit zero width
  - auto-detected width (including >120)
  - detection fallback
  - non-TTY fallback
- Ran:
  - `go test -count=1 ./...`

## Closes

Closes #942