### PR TITLE
feat: allow choosing editor in configuration file

### DIFF
--- a/config_cmd.go
+++ b/config_cmd.go
@@ -23,13 +23,16 @@ pager: false
 width: 80
 # show all files, including hidden and ignored.
 all: false
+# editor used to open files (defaults to $EDITOR, or "nano" if unset).
+# Accepts an editor name or a command with flags, e.g. "code --wait".
+editor: ""
 `
 
 var configCmd = &cobra.Command{
 	Use:     "config",
 	Hidden:  false,
 	Short:   "Edit the glow config file",
-	Long:    paragraph(fmt.Sprintf("\n%s the glow config file. We’ll use EDITOR to determine which editor to use. If the config file doesn't exist, it will be created.", keyword("Edit"))),
+	Long:    paragraph(fmt.Sprintf("\n%s the glow config file. The editor is chosen from the `editor` config key, falling back to $EDITOR (and finally nano) if unset. If the config file doesn't exist, it will be created.", keyword("Edit"))),
 	Example: paragraph("glow config\nglow config --config path/to/config.yml"),
 	Args:    cobra.NoArgs,
 	RunE: func(*cobra.Command, []string) error {

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ var (
 	showLineNumbers  bool
 	preserveNewLines bool
 	mouse            bool
+	editorOverride   string
 
 	rootCmd = &cobra.Command{
 		Use:   "glow [SOURCE|DIR]",
@@ -173,6 +174,15 @@ func validateOptions(cmd *cobra.Command) error {
 	showAllFiles = viper.GetBool("all")
 	preserveNewLines = viper.GetBool("preserveNewLines")
 	showLineNumbers = viper.GetBool("showLineNumbers")
+	editorOverride = viper.GetString("editor")
+
+	// Apply the configured editor to this process so the embedded x/editor
+	// package (used by `glow config` and the in-TUI editor key) picks it up.
+	// The override only affects this glow invocation and does not leak into
+	// the user's shell environment.
+	if editorOverride != "" {
+		_ = os.Setenv("EDITOR", editorOverride)
+	}
 
 	if pager && tui {
 		return errors.New("cannot use both pager and tui")


### PR DESCRIPTION
Closes #944.

Adds an `editor` key to `glow.yml` so users can pick the editor used by `glow config` and the in-TUI `e` key without having to override `$EDITOR` globally. The use case from the issue is wanting `micro` for markdown while keeping `vim` as the system default.

### Behavior

```yaml
# editor used to open files (defaults to $EDITOR, or "nano" if unset).
# Accepts an editor name or a command with flags, e.g. "code --wait".
editor: ""
```

- `editor: "micro"` → glow uses `micro`, ignoring `$EDITOR`.
- `editor: "code --wait"` → multi-token commands work (the `x/editor` package already splits on whitespace).
- `editor: ""` or unset → existing `$EDITOR` → `nano` fallback chain is untouched.

### Implementation note

When the key is set, the value is applied to glow's own process environment in `validateOptions` before `editor.Cmd` runs. This keeps the diff tiny (no plumbing through `ui.Config`, no fork of the upstream `charmbracelet/x/editor` package) and only mutates glow's own process, so the user's shell `$EDITOR` is not affected.

### Verified locally

- `editor: "/bin/echo override"` + a stub `EDITOR` → fake editor invoked with the config file path.
- `editor: ""` + `EDITOR=/bin/echo` → `$EDITOR` is used.
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
