### PR TITLE
fix: `--style` flag overrides `GLAMOUR_STYLE` in TUI

### DIFF
--- a/glow_test.go
+++ b/glow_test.go
@@ -39,3 +39,28 @@ func TestGlowFlags(t *testing.T) {
 		}
 	}
 }
+
+func TestResolveTUIStyle(t *testing.T) {
+	cases := []struct {
+		name       string
+		envStyle   string
+		cliStyle   string
+		cliChanged bool
+		want       string
+	}{
+		{"cli flag wins over env", "dark", "light", true, "light"},
+		{"env wins when valid and no cli", "dark", "auto", false, "dark"},
+		{"cli wins when env unset", "", "light", false, "light"},
+		{"cli wins when env unknown", "bogus", "light", false, "light"},
+		{"env auto preserved without cli", "auto", "light", false, "auto"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveTUIStyle(tc.envStyle, tc.cliStyle, tc.cliChanged)
+			if got != tc.want {
+				t.Errorf("resolveTUIStyle(%q, %q, %v) = %q, want %q",
+					tc.envStyle, tc.cliStyle, tc.cliChanged, got, tc.want)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -164,6 +164,16 @@ func validateStyle(style string) error {
 	return nil
 }
 
+// resolveTUIStyle picks the glamour style for the TUI. An explicit --style
+// flag wins over GLAMOUR_STYLE; otherwise a valid env value wins; otherwise
+// we fall back to the viper-resolved CLI style.
+func resolveTUIStyle(envStyle, cliStyle string, cliChanged bool) string {
+	if cliChanged || validateStyle(envStyle) != nil {
+		return cliStyle
+	}
+	return envStyle
+}
+
 func validateOptions(cmd *cobra.Command) error {
 	// grab config values from Viper
 	width = viper.GetUint("width")
@@ -235,7 +245,7 @@ func execute(cmd *cobra.Command, args []string) error {
 	switch len(args) {
 	// TUI running on cwd
 	case 0:
-		return runTUI("", "")
+		return runTUI(cmd, "", "")
 
 	// TUI with possible dir argument
 	case 1:
@@ -245,7 +255,7 @@ func execute(cmd *cobra.Command, args []string) error {
 		if err == nil && info.IsDir() {
 			p, err := filepath.Abs(args[0])
 			if err == nil {
-				return runTUI(p, "")
+				return runTUI(cmd, p, "")
 			}
 		}
 		fallthrough
@@ -337,7 +347,7 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 		if !isURL(src.URL) {
 			path = src.URL
 		}
-		return runTUI(path, content)
+		return runTUI(cmd, path, content)
 	default:
 		if _, err = fmt.Fprint(w, out); err != nil {
 			return fmt.Errorf("unable to write to writer: %w", err)
@@ -346,17 +356,14 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 	}
 }
 
-func runTUI(path string, content string) error {
+func runTUI(cmd *cobra.Command, path string, content string) error {
 	// Read environment to get debugging stuff
 	cfg, err := env.ParseAs[ui.Config]()
 	if err != nil {
 		return fmt.Errorf("error parsing config: %v", err)
 	}
 
-	// use style set in env, or auto if unset
-	if err := validateStyle(cfg.GlamourStyle); err != nil {
-		cfg.GlamourStyle = style
-	}
+	cfg.GlamourStyle = resolveTUIStyle(cfg.GlamourStyle, style, cmd.Flags().Changed("style"))
 
 	cfg.Path = path
 	cfg.ShowAllFiles = showAllFiles


### PR DESCRIPTION
## Summary

`glow --tui -s light` (or any explicit `--style`) is silently ignored when `GLAMOUR_STYLE` is set to a known style. The env var wins over the CLI flag, which is the opposite of normal CLI precedence.

Reproduction:

```
$ export GLAMOUR_STYLE=dark
$ glow --tui -s light .   # still renders with the dark style
```

## Cause

`runTUI` validates the env-provided style and only falls back to the CLI flag when validation fails. If `GLAMOUR_STYLE` is a valid known style, the CLI flag never wins.

```go
// before
if err := validateStyle(cfg.GlamourStyle); err != nil {
    cfg.GlamourStyle = style
}
```

## Fix

Reverse the precedence: an explicit `--style` flag always wins, otherwise a valid env value wins, otherwise viper's resolved style. The same `cmd.Flags().Changed("style")` pattern is already used in `validateOptions` for the no-TTY case, so this is consistent with the rest of `main.go`.

```go
// after
cfg.GlamourStyle = resolveTUIStyle(cfg.GlamourStyle, style, cmd.Flags().Changed("style"))
```

The new `resolveTUIStyle` helper keeps the rule legible and testable.

## Testing

- `go build ./...` clean
- `go test ./...` clean (existing `TestGlowFlags` plus new `TestResolveTUIStyle` with five cases)
- Empirically verified with a debug build:
  - `-s light` (env unset) → `light`
  - `-s light` (env=`dark`) → `light` (was: `dark`)
  - no flag, env=`dark` → `dark` (env still wins without explicit CLI)
  - no flag, env unset → falls back to viper's resolved style

Fixes #953