### PR TITLE
feat: sort markdown files by directory depth

### DIFF
--- a/ui/sort.go
+++ b/ui/sort.go
@@ -2,11 +2,24 @@ package ui
 
 import (
 	"cmp"
+	"path/filepath"
 	"slices"
+	"strings"
 )
 
 func sortMarkdowns(mds []*markdown) {
 	slices.SortStableFunc(mds, func(a, b *markdown) int {
+		if n := cmp.Compare(markdownPathDepth(a.Note), markdownPathDepth(b.Note)); n != 0 {
+			return n
+		}
 		return cmp.Compare(a.Note, b.Note)
 	})
+}
+
+func markdownPathDepth(path string) int {
+	path = filepath.ToSlash(filepath.Clean(path))
+	if path == "." {
+		return 0
+	}
+	return strings.Count(path, "/")
 }

--- a/ui/sort_test.go
+++ b/ui/sort_test.go
@@ -1,0 +1,33 @@
+package ui
+
+import "testing"
+
+func TestSortMarkdownsOrdersByDirectoryDepth(t *testing.T) {
+	mds := []*markdown{
+		{Note: "docs/reference/api.md"},
+		{Note: "docs/guide.md"},
+		{Note: "README.md"},
+		{Note: "CONTRIBUTING.md"},
+		{Note: "docs/reference/cli.md"},
+	}
+
+	sortMarkdowns(mds)
+
+	got := make([]string, 0, len(mds))
+	for _, md := range mds {
+		got = append(got, md.Note)
+	}
+
+	want := []string{
+		"CONTRIBUTING.md",
+		"README.md",
+		"docs/guide.md",
+		"docs/reference/api.md",
+		"docs/reference/cli.md",
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Sorts discovered TUI markdown files by directory depth before path/title ordering.

This keeps files in the directory where Glow is browsing ahead of files in nested folders, while preserving the existing alphabetical path sort for files at the same depth.

## Testing

- `go test ./...`
- `go test -race -covermode atomic ./...`
- `git diff --check`

Fixes #272
