### PR TITLE
fix: show symlinked files under their own name instead of target's name

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -432,7 +432,11 @@ func localFileToMarkdown(cwd string, res gitcha.SearchResult) *markdown {
 }
 
 func stripAbsolutePath(fullPath, cwd string) string {
-	fp, _ := filepath.EvalSymlinks(fullPath)
+	// Don't resolve symlinks on fullPath — use the original path so that
+	// symlinked files display under their own name (e.g. AGENTS.md) instead
+	// of their target's name (e.g. CLAUDE.md).
+	// We still resolve cwd in case the working directory itself is a symlink.
+	fp := fullPath
 	cp, _ := filepath.EvalSymlinks(cwd)
 	return strings.ReplaceAll(fp, cp+string(os.PathSeparator), "")
 }


### PR DESCRIPTION
## Problem

Symlinked markdown files appear under their target's name in the TUI document list. If you have a real file and a symlink pointing at it, both show up with the same name, making them indistinguishable.

**Reproduction:**
1. `printf '# Hello\n' > CLAUDE.md`
2. `ln -s CLAUDE.md AGENTS.md`
3. `glow`

Result: two entries both named `CLAUDE.md`. Expected: one `CLAUDE.md` and one `AGENTS.md`.

## Root Cause

`stripAbsolutePath` in `ui/ui.go` calls `filepath.EvalSymlinks(fullPath)`, which resolves symlinks and rewrites the link's display name to its target.

## Fix

Use the original path for display instead of the resolved path. We still resolve `cwd` in case the working directory itself is a symlink.

Fixes #965