### PR TITLE
Skip broken symlink markdown files

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -291,6 +291,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case foundLocalFileMsg:
 		newMd := localFileToMarkdown(m.common.cwd, gitcha.SearchResult(msg))
+		if newMd == nil {
+			cmds = append(cmds, findNextLocalFile(m))
+			break
+		}
 		m.stash.addMarkdowns(newMd)
 		if m.stash.filterApplied() {
 			newMd.buildFilterValue()
@@ -421,9 +425,13 @@ func waitForStatusMessageTimeout(appCtx applicationContext, t *time.Timer) tea.C
 // ETC
 
 // Convert a Gitcha result to an internal representation of a markdown
-// document. Note that we could be doing things like checking if the file is
-// a directory, but we trust that gitcha has already done that.
+// document.
 func localFileToMarkdown(cwd string, res gitcha.SearchResult) *markdown {
+	if _, err := os.Stat(res.Path); err != nil {
+		log.Debug("skipping unreadable local markdown", "file", res.Path, "error", err)
+		return nil
+	}
+
 	return &markdown{
 		localPath: res.Path,
 		Note:      stripAbsolutePath(res.Path, cwd),

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -1,0 +1,33 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/muesli/gitcha"
+)
+
+func TestLocalFileToMarkdownSkipsBrokenSymlink(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "broken.md")
+
+	err := os.Symlink(filepath.Join(dir, "missing.md"), path)
+	if err != nil {
+		t.Skipf("symlinks are not available: %v", err)
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("expected to stat symlink: %v", err)
+	}
+
+	md := localFileToMarkdown(dir, gitcha.SearchResult{
+		Path: path,
+		Info: info,
+	})
+
+	if md != nil {
+		t.Fatalf("expected broken symlink to be skipped, got note %q", md.Note)
+	}
+}


### PR DESCRIPTION
Fixes #836

## Summary

- Skip local markdown search results that no longer resolve, including dangling symlinks.
- Continue scanning after a skipped local file instead of adding an empty document entry.
- Add regression coverage for a broken `.md` symlink.

## Testing

- `go test ./ui`
- `go test ./...`
- `git diff --check`