### PR TITLE
FIX load style from cfg/env in cli mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -179,7 +179,16 @@ func validateOptions(cmd *cobra.Command) error {
 	}
 
 	// validate the glamour style
+	// via cfg, mirroring the TUI path
+	cfg, err := env.ParseAs[ui.Config]()
+	if err != nil {
+		return fmt.Errorf("error parsing config: %v", err)
+	}
+
 	style = viper.GetString("style")
+	if cfg.GlamourStyle != "" {
+		style = cfg.GlamourStyle
+	}
 	if err := validateStyle(style); err != nil {
 		return err
 	}
@@ -189,6 +198,10 @@ func validateOptions(cmd *cobra.Command) error {
 	// and there was no specific style passed by arg
 	if !isTerminal && !cmd.Flags().Changed("style") {
 		style = "notty"
+	}
+
+	if cfg.GlamourMaxWidth != 0 {
+		width = cfg.GlamourMaxWidth
 	}
 
 	// Detect terminal width


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [N/A] I have created a discussion that was approved by a maintainer (for new features).

When rendering via cli (no tui) the cfg/env is not read for the style and width settings so doesn't appear as expected eg.
`glow file.md` or  `cat file.md |glow`.
