### PR TITLE
fix: use TokyoNight config for tokyo-night code rendering

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -101,7 +101,7 @@ func GlamourStyle(style string, isCode bool) glamour.TermRendererOption {
 	case styles.DraculaStyle:
 		styleConfig = styles.DraculaStyleConfig
 	case styles.TokyoNightStyle:
-		styleConfig = styles.DraculaStyleConfig
+		styleConfig = styles.TokyoNightStyleConfig
 	default:
 		return glamour.WithStylesFromJSONFile(style)
 	}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/glamour"
+	"github.com/charmbracelet/glamour/styles"
+)
+
+// renderCode renders a fenced code block with the given style in code mode.
+func renderCode(t *testing.T, style string) string {
+	t.Helper()
+	r, err := glamour.NewTermRenderer(GlamourStyle(style, true))
+	if err != nil {
+		t.Fatalf("new renderer for %q: %v", style, err)
+	}
+	out, err := r.Render("```go\nfmt.Println(\"hello\")\n```\n")
+	if err != nil {
+		t.Fatalf("render with %q: %v", style, err)
+	}
+	return out
+}
+
+// TestGlamourStyleTokyoNightCodeDistinctFromDracula guards against the
+// tokyo-night code style being mapped to the dracula StyleConfig. The two
+// themes use different colors, so their rendered code output must differ.
+func TestGlamourStyleTokyoNightCodeDistinctFromDracula(t *testing.T) {
+	t.Setenv("CLICOLOR_FORCE", "1") // force ANSI color so styles are distinguishable
+
+	tokyo := renderCode(t, styles.TokyoNightStyle)
+	dracula := renderCode(t, styles.DraculaStyle)
+
+	if tokyo == dracula {
+		t.Errorf("tokyo-night code rendering is identical to dracula; GlamourStyle must use TokyoNightStyleConfig")
+	}
+}


### PR DESCRIPTION
### What's wrong

In `GlamourStyle(style, isCode)`, the branch that builds a `StyleConfig` for rendering **pure code files** (non-markdown extensions, `isCode == true`) maps `tokyo-night` to the **Dracula** config:

```go
case styles.TokyoNightStyle:
    styleConfig = styles.DraculaStyleConfig // wrong
```

So `glow --style tokyo-night <codefile>` renders code with Dracula colors instead of Tokyo Night. glamour exports a distinct `styles.TokyoNightStyleConfig` (different palette), and every other case in the switch maps to its own config — tokyo-night is the lone copy-paste mistake.

(Regular markdown rendering with `tokyo-night` is unaffected; it goes through glamour's `WithStylePath`. This bug is specific to the code-file branch.)

### Fix

One line: `case styles.TokyoNightStyle:` → `styles.TokyoNightStyleConfig`.

### Testing

Added `utils/utils_test.go`: renders a code block with `tokyo-night` and `dracula` (color forced via `CLICOLOR_FORCE`) and asserts the output differs. Fails before the fix (identical output), passes after. `go test ./utils/` green.
