### PR TITLE
fix: show spinner when reloading with `r` key

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -229,6 +229,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, cmd
 				}
 				m.stash.markdowns = nil
+				m.stash.loaded = false // reset load state
 				return m, m.Init()
 			}
 


### PR DESCRIPTION
fixes #980 