### PR TITLE
fix(pager): use temp file and TTY for interactive pagers like most

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,11 +9,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
-
-	"mvdan.cc/sh/v3/shell"
 
 	"github.com/caarlos0/env/v11"
 	"github.com/charmbracelet/glamour"
@@ -316,20 +313,8 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 	// display
 	switch {
 	case pager || cmd.Flags().Changed("pager"):
-		pagerCmd := os.Getenv("PAGER")
-		if pagerCmd == "" {
-			pagerCmd = "less -r"
-		}
-
-		fields, err := shell.Fields(pagerCmd, os.Getenv)
-		if err != nil || len(fields) == 0 {
-			return fmt.Errorf("unable to parse PAGER command: %s", pagerCmd)
-		}
-		c := exec.Command(fields[0], fields[1:]...) //nolint:gosec
-		c.Stdin = strings.NewReader(out)
-		c.Stdout = os.Stdout
-		if err := c.Run(); err != nil {
-			return fmt.Errorf("unable to run command: %w", err)
+		if err := runPagerCommand(out); err != nil {
+			return err
 		}
 		return nil
 	case tui || cmd.Flags().Changed("tui"):

--- a/pager.go
+++ b/pager.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"mvdan.cc/sh/v3/shell"
+)
+
+func runPagerCommand(content string) error {
+	pagerCmd := os.Getenv("PAGER")
+	if pagerCmd == "" {
+		pagerCmd = "less -r"
+	}
+
+	fields, err := shell.Fields(pagerCmd, os.Getenv)
+	if err != nil || len(fields) == 0 {
+		return fmt.Errorf("unable to parse PAGER command: %q", pagerCmd)
+	}
+
+	f, err := os.CreateTemp("", "glow-*.md")
+	if err != nil {
+		return fmt.Errorf("unable to create pager temp file: %w", err)
+	}
+	name := f.Name()
+	defer os.Remove(name)
+
+	if _, err := f.WriteString(content); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("unable to write pager temp file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("unable to close pager temp file: %w", err)
+	}
+
+	args := append(append([]string{}, fields[1:]...), name)
+	c := exec.Command(fields[0], args...) //nolint:gosec
+	c.Stdout = os.Stdout
+
+	// Interactive pagers like `most` read file arguments but need a real TTY
+	// for keyboard input. Piping rendered content on stdin breaks them (#153).
+	if tty := pagerTTY(); tty != nil {
+		defer tty.Close()
+		c.Stdin = tty
+	}
+
+	var stderr strings.Builder
+	c.Stderr = &stderr
+
+	if err := c.Run(); err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return fmt.Errorf("pager %q failed: %w: %s", fields[0], err, msg)
+		}
+		return fmt.Errorf("pager %q failed: %w", fields[0], err)
+	}
+	return nil
+}
+
+func pagerTTY() io.ReadCloser {
+	for _, path := range []string{"/dev/tty", "CONIN$"} {
+		f, err := os.Open(path)
+		if err == nil {
+			return f
+		}
+	}
+	return nil
+}

--- a/pager_test.go
+++ b/pager_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writePagerScript(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	script := filepath.Join(dir, name)
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return script
+}
+
+func TestRunPagerCommandUsesTempFile(t *testing.T) {
+	dir := t.TempDir()
+	script := writePagerScript(t, dir, "pager.sh", `#!/bin/sh
+if [ ! -f "$1" ]; then
+  echo "missing pager file arg" >&2
+  exit 2
+fi
+cat "$1"
+`)
+
+	t.Setenv("PAGER", script)
+	if err := runPagerCommand("rendered markdown\n"); err != nil {
+		t.Fatalf("runPagerCommand: %v", err)
+	}
+}
+
+func TestRunPagerCommandEmptyContent(t *testing.T) {
+	dir := t.TempDir()
+	script := writePagerScript(t, dir, "pager.sh", `#!/bin/sh
+test -f "$1"
+`)
+
+	t.Setenv("PAGER", script)
+	if err := runPagerCommand(""); err != nil {
+		t.Fatalf("runPagerCommand: %v", err)
+	}
+}
+
+func TestRunPagerCommandRespectsPagerFlags(t *testing.T) {
+	dir := t.TempDir()
+	script := writePagerScript(t, dir, "pager.sh", `#!/bin/sh
+if [ "$1" != "-r" ] || [ ! -f "$2" ]; then
+  echo "unexpected pager args: $*" >&2
+  exit 2
+fi
+cat "$2"
+`)
+
+	t.Setenv("PAGER", script+" -r")
+	if err := runPagerCommand("flagged pager\n"); err != nil {
+		t.Fatalf("runPagerCommand: %v", err)
+	}
+}
+
+func TestRunPagerCommandIncludesPagerStderr(t *testing.T) {
+	dir := t.TempDir()
+	script := writePagerScript(t, dir, "pager.sh", `#!/bin/sh
+echo "pager rejected input" >&2
+exit 1
+`)
+
+	t.Setenv("PAGER", script)
+	err := runPagerCommand("content\n")
+	if err == nil {
+		t.Fatal("expected pager failure")
+	}
+	if !strings.Contains(err.Error(), "pager rejected input") {
+		t.Fatalf("expected pager stderr in error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes `glow -p` failing when `PAGER` is set to interactive pagers like `most` that reject piped stdin.

## Motivation

`glow -p` previously piped rendered markdown directly to the pager process stdin. Pagers such as `most` expect a file path argument and read keyboard input from the controlling terminal, so they exit with status 1 (#153).

## Changes

- Add `runPagerCommand()` that writes rendered output to a private temp file and passes the file path to the configured pager
- Attach `/dev/tty` (or `CONIN$` on Windows) for pager keyboard input
- Include pager stderr in failure messages for easier diagnosis (complements #948)

## Tests

- `go test ./...` — all pass
- Added pager unit tests covering temp-file handoff, pager flags, empty content, and stderr error propagation

## Notes

- Supersedes the diagnostic-only approach in #948 by fixing the underlying `most` compatibility issue while keeping improved error messages.
- Large documents incur a brief temp-file write; this matches common pager integrations (`man`, `git`, etc.).

Fixes #153