### PR TITLE
fix(cli): respect preserve-new-lines flag in CLI renderer

### DIFF
--- a/glow_test.go
+++ b/glow_test.go
@@ -1,10 +1,22 @@
 package main
 
 import (
+	"bytes"
+	"io"
+	"regexp"
+	"strings"
+	"sync"
 	"testing"
+
+	"github.com/spf13/viper"
 )
 
+var cliTestMu sync.Mutex
+
 func TestGlowFlags(t *testing.T) {
+	cliTestMu.Lock()
+	defer cliTestMu.Unlock()
+
 	tt := []struct {
 		args  []string
 		check func() bool
@@ -39,3 +51,55 @@ func TestGlowFlags(t *testing.T) {
 		}
 	}
 }
+
+func TestCLIPreserveNewLinesFlag(t *testing.T) {
+	cliTestMu.Lock()
+	defer cliTestMu.Unlock()
+
+	md := "soft\nbreak\n"
+
+	render := func(preserve bool) string {
+		oldPreserve := preserveNewLines
+		oldStyle := style
+		oldWidth := width
+		oldPager := pager
+		oldTUI := tui
+		t.Cleanup(func() {
+			preserveNewLines = oldPreserve
+			style = oldStyle
+			width = oldWidth
+			pager = oldPager
+			tui = oldTUI
+		})
+
+		preserveNewLines = preserve
+		style = "notty"
+		width = 80
+		pager = false
+		tui = false
+		viper.Set("pager", false)
+		viper.Set("tui", false)
+		_ = rootCmd.Flags().Set("pager", "false")
+		_ = rootCmd.Flags().Set("tui", "false")
+		rootCmd.Flags().Lookup("pager").Changed = false
+		rootCmd.Flags().Lookup("tui").Changed = false
+
+		var buf bytes.Buffer
+		src := &source{reader: io.NopCloser(strings.NewReader(md)), URL: "test.md"}
+		if err := executeCLI(rootCmd, src, &buf); err != nil {
+			t.Fatalf("executeCLI failed: %v", err)
+		}
+		return ansiStrip.ReplaceAllString(buf.String(), "")
+	}
+
+	outFalse := render(false)
+	outTrue := render(true)
+	if strings.Contains(outFalse, "soft\nbreak") {
+		t.Fatalf("expected soft line break to collapse when preserve-new-lines is false, got: %q", outFalse)
+	}
+	if outFalse == outTrue {
+		t.Fatalf("expected preserve-new-lines flag to change rendering")
+	}
+}
+
+var ansiStrip = regexp.MustCompile(`\x1b\[[0-9;]*m`)

--- a/main.go
+++ b/main.go
@@ -291,13 +291,16 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 	isCode := !utils.IsMarkdownFile(src.URL)
 
 	// initialize glamour
-	r, err := glamour.NewTermRenderer(
+	options := []glamour.TermRendererOption{
 		glamour.WithColorProfile(lipgloss.ColorProfile()),
 		utils.GlamourStyle(style, isCode),
 		glamour.WithWordWrap(int(width)), //nolint:gosec
 		glamour.WithBaseURL(baseURL),
-		glamour.WithPreservedNewLines(),
-	)
+	}
+	if preserveNewLines {
+		options = append(options, glamour.WithPreservedNewLines())
+	}
+	r, err := glamour.NewTermRenderer(options...)
 	if err != nil {
 		return fmt.Errorf("unable to create renderer: %w", err)
 	}


### PR DESCRIPTION
## Summary
CLI mode always passed `glamour.WithPreservedNewLines()`, ignoring the `-n` flag and config default.

## Motivation
TUI mode already respects `preserveNewLines` in `ui/pager.go`, but `executeCLI` forced preserved newlines for every render. That made CLI output differ from TUI and contributed to glow #858 list rendering complaints.

## Changes
- Build CLI glamour options conditionally, matching TUI behavior
- Add `TestCLIPreserveNewLinesFlag` to verify the default path collapses soft breaks

## Tests
- `go test ./... -count=1` — pass

## Notes
Full fix for list soft breaks inside list items requires the companion glamour change in charmbracelet/glamour#580 and a follow-up dependency bump once released.

Related to #858