### PR TITLE
fix(tui): respect --style / config over GLAMOUR_STYLE env

### DIFF
--- a/main.go
+++ b/main.go
@@ -353,8 +353,13 @@ func runTUI(path string, content string) error {
 		return fmt.Errorf("error parsing config: %v", err)
 	}
 
-	// use style set in env, or auto if unset
-	if err := validateStyle(cfg.GlamourStyle); err != nil {
+	// Prefer CLI/config style (resolved in validateOptions) when it is not
+	// the default "auto". Otherwise fall back to GLAMOUR_STYLE from the
+	// environment, then to auto. Previously an env value such as "auto" or
+	// "dark" silently ignored `-s light` / config `style` in TUI mode (#953).
+	if style != styles.AutoStyle {
+		cfg.GlamourStyle = style
+	} else if err := validateStyle(cfg.GlamourStyle); err != nil || cfg.GlamourStyle == "" {
 		cfg.GlamourStyle = style
 	}
 


### PR DESCRIPTION
## Description

`runTUI` previously applied the resolved CLI/config `style` only when `GLAMOUR_STYLE` failed validation. A valid env value (including `auto` or `dark`) therefore ignored `-s light` / config `style` in TUI mode.

Now an explicit non-`auto` style from flags/config wins; otherwise the env value is used, then `auto`.

## Motivation and Context

Fixes #953.

## How Has This Been Tested?

- `go test ./...`
- Platform: macOS aarch64

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/charmbracelet/glow/blob/master/.github/contributing.md) (if present)
- [x] I have tested my changes


Made with [Cursor](https://cursor.com)