### PR TITLE
fix: disable high-performance pager rendering by default

### DIFF
--- a/ui/config.go
+++ b/ui/config.go
@@ -15,6 +15,11 @@ type Config struct {
 	Path string
 
 	// For debugging the UI
-	HighPerformancePager bool `env:"GLOW_HIGH_PERFORMANCE_PAGER" envDefault:"true"`
+	//
+	// Defaults to false: bubbletea's high-performance/scroll-region
+	// rendering is deprecated upstream and known to corrupt output on
+	// several terminals (e.g. kitty) during scroll. See #554. Users can
+	// still opt in via GLOW_HIGH_PERFORMANCE_PAGER=true.
+	HighPerformancePager bool `env:"GLOW_HIGH_PERFORMANCE_PAGER" envDefault:"false"`
 	GlamourEnabled       bool `env:"GLOW_ENABLE_GLAMOUR"         envDefault:"true"`
 }

--- a/ui/config_test.go
+++ b/ui/config_test.go
@@ -1,0 +1,46 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/caarlos0/env/v11"
+)
+
+func TestConfig_HighPerformancePagerDefault(t *testing.T) {
+	t.Setenv("GLOW_HIGH_PERFORMANCE_PAGER", "")
+
+	cfg, err := env.ParseAs[Config]()
+	if err != nil {
+		t.Fatalf("env.ParseAs[Config]() error = %v", err)
+	}
+
+	if cfg.HighPerformancePager {
+		t.Errorf("HighPerformancePager default = true, want false (see #554: high-performance rendering is deprecated upstream and corrupts scroll on some terminals)")
+	}
+}
+
+func TestConfig_HighPerformancePagerOptIn(t *testing.T) {
+	t.Setenv("GLOW_HIGH_PERFORMANCE_PAGER", "true")
+
+	cfg, err := env.ParseAs[Config]()
+	if err != nil {
+		t.Fatalf("env.ParseAs[Config]() error = %v", err)
+	}
+
+	if !cfg.HighPerformancePager {
+		t.Error("HighPerformancePager with GLOW_HIGH_PERFORMANCE_PAGER=true = false, want true (opt-in must still work)")
+	}
+}
+
+func TestConfig_HighPerformancePagerExplicitOff(t *testing.T) {
+	t.Setenv("GLOW_HIGH_PERFORMANCE_PAGER", "false")
+
+	cfg, err := env.ParseAs[Config]()
+	if err != nil {
+		t.Fatalf("env.ParseAs[Config]() error = %v", err)
+	}
+
+	if cfg.HighPerformancePager {
+		t.Error("HighPerformancePager with GLOW_HIGH_PERFORMANCE_PAGER=false = true, want false")
+	}
+}

--- a/ui/config_test.go
+++ b/ui/config_test.go
@@ -7,6 +7,10 @@ import (
 )
 
 func TestConfig_HighPerformancePagerDefault(t *testing.T) {
+	// caarlos0/env treats a set-but-empty var the same as unset when a
+	// default exists (env.getOr: `exists && value == "" && defExists`),
+	// so setting "" here exercises the same envDefault path as a truly
+	// unset var.
 	t.Setenv("GLOW_HIGH_PERFORMANCE_PAGER", "")
 
 	cfg, err := env.ParseAs[Config]()

--- a/ui/pager_test.go
+++ b/ui/pager_test.go
@@ -1,0 +1,35 @@
+package ui
+
+import "testing"
+
+// newPagerModel wires viewport.HighPerformanceRendering from the
+// package-level config var (set via NewProgram in normal operation).
+// These tests set it directly to exercise that wiring in isolation.
+
+func TestNewPagerModel_HighPerformanceRenderingOff(t *testing.T) {
+	old := config
+	defer func() { config = old }()
+
+	config = Config{HighPerformancePager: false}
+	common := &commonModel{cfg: config}
+
+	m := newPagerModel(common)
+
+	if m.viewport.HighPerformanceRendering {
+		t.Error("viewport.HighPerformanceRendering = true, want false when config.HighPerformancePager is false (see #554)")
+	}
+}
+
+func TestNewPagerModel_HighPerformanceRenderingOptIn(t *testing.T) {
+	old := config
+	defer func() { config = old }()
+
+	config = Config{HighPerformancePager: true}
+	common := &commonModel{cfg: config}
+
+	m := newPagerModel(common)
+
+	if !m.viewport.HighPerformanceRendering {
+		t.Error("viewport.HighPerformanceRendering = false, want true when config.HighPerformancePager is explicitly true (opt-in must still work)")
+	}
+}


### PR DESCRIPTION
## Summary

`HighPerformancePager` defaulted to `true`, wiring bubbles' `viewport.HighPerformanceRendering` on by default. That mode bypasses bubbletea's normal renderer with raw ANSI scroll-region escapes and is now marked deprecated upstream (`bubbles/viewport`: "high performance rendering is now deprecated in Bubble Tea"). Several terminals (e.g. kitty, per the report) don't render the scroll-region escapes correctly, which produces the shuffled/duplicated lines described in #554 after scrolling with `u`/`d` or the mouse wheel.

This defaults the pager to the standard renderer. `GLOW_HIGH_PERFORMANCE_PAGER=true` still opts back in for anyone who wants it.

## Changes

- `ui/config.go`: flip `HighPerformancePager`'s `envDefault` from `"true"` to `"false"`.
- `ui/config_test.go` (new): covers default / explicit-off / explicit-on for the env var.
- `ui/pager_test.go` (new): covers that `newPagerModel` wires `config.HighPerformancePager` into `viewport.HighPerformanceRendering` correctly in both directions.

No behavioral logic changes to `pager.go`/`ui.go` — those already branch correctly on `HighPerformanceRendering`; this is a config-default fix plus the test coverage that path was missing.

## Test plan

- `go test ./ui/...` — all pass, including the new tests.
- `go build ./...` and full `go test ./...` — pass, no regressions.

Fixes #554