### PR TITLE
fix: missing-user-entrypoint-3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM gcr.io/distroless/static
 COPY glow /usr/local/bin/glow
+USER nonroot
 ENTRYPOINT [ "/usr/local/bin/glow" ]


### PR DESCRIPTION
  Summary — missing-user-entrypoint

File: Dockerfile

Problem: No USER instruction was defined, causing the container process (glow) to run as root by default. This is a security hazard — if an attacker gains control of the process, they may gain full control of the container.

Fix Applied: Added USER nonroot immediately before the ENTRYPOINT instruction.

FROM gcr.io/distroless/static
COPY glow /usr/local/bin/glow
USER nonroot                          # ← Added
ENTRYPOINT [ "/usr/local/bin/glow" ]
Why nonroot? The base image gcr.io/distroless/static ships with a built-in, unprivileged user called nonroot (UID 65532). Using this user is the idiomatic and safe choice for distroless images — no need to create a custom user. This ensures the glow binary runs with the least privilege necessary.