### PR TITLE
feat: expose hyperlinkMode as a config option

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ var (
 	showLineNumbers  bool
 	preserveNewLines bool
 	mouse            bool
+	hyperlinkMode    string
 
 	rootCmd = &cobra.Command{
 		Use:   "glow [SOURCE|DIR]",
@@ -173,6 +174,7 @@ func validateOptions(cmd *cobra.Command) error {
 	showAllFiles = viper.GetBool("all")
 	preserveNewLines = viper.GetBool("preserveNewLines")
 	showLineNumbers = viper.GetBool("showLineNumbers")
+	hyperlinkMode = viper.GetString("hyperlinkMode")
 
 	if pager && tui {
 		return errors.New("cannot use both pager and tui")
@@ -297,8 +299,13 @@ func executeCLI(cmd *cobra.Command, src *source, w io.Writer) error {
 		glamour.WithBaseURL(baseURL),
 		glamour.WithPreservedNewLines(),
 	}
-	if utils.SupportsHyperlinks(os.Environ()) {
+	switch hyperlinkMode {
+	case "inline":
 		options = append(options, glamour.WithHyperlinkMode(glamsi.HyperlinkModeInline))
+	case "auto", "":
+		if utils.SupportsHyperlinks(os.Environ()) {
+			options = append(options, glamour.WithHyperlinkMode(glamsi.HyperlinkModeInline))
+		}
 	}
 	r, err := glamour.NewTermRenderer(options...)
 	if err != nil {
@@ -367,6 +374,7 @@ func runTUI(path string, content string) error {
 	cfg.GlamourMaxWidth = width
 	cfg.EnableMouse = mouse
 	cfg.PreserveNewLines = preserveNewLines
+	cfg.HyperlinkMode = hyperlinkMode
 
 	// Run Bubble Tea program
 	if _, err := ui.NewProgram(cfg, content).Run(); err != nil {
@@ -426,6 +434,7 @@ func init() {
 
 	viper.SetDefault("style", "auto")
 	viper.SetDefault("width", 0)
+	viper.SetDefault("hyperlinkMode", "auto")
 	viper.SetDefault("all", true)
 
 	rootCmd.AddCommand(configCmd, manCmd)

--- a/ui/config.go
+++ b/ui/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	GlamourStyle     string `env:"GLAMOUR_STYLE"`
 	EnableMouse      bool
 	PreserveNewLines bool
+	HyperlinkMode    string
 
 	// Working directory or file path
 	Path string

--- a/ui/pager.go
+++ b/ui/pager.go
@@ -371,8 +371,13 @@ func glamourRender(m pagerModel, markdown string) (string, error) {
 		glamour.WithWordWrap(width),
 	}
 
-	if utils.SupportsHyperlinks(os.Environ()) {
+	switch m.common.cfg.HyperlinkMode {
+	case "inline":
 		options = append(options, glamour.WithHyperlinkMode(glamsi.HyperlinkModeInline))
+	case "auto", "":
+		if utils.SupportsHyperlinks(os.Environ()) {
+			options = append(options, glamour.WithHyperlinkMode(glamsi.HyperlinkModeInline))
+		}
 	}
 
 	if m.common.cfg.PreserveNewLines {


### PR DESCRIPTION
## Summary

- Adds `hyperlinkMode` to `glow.yml` config with values: `"auto"` (detect terminal support via env), `"inline"` (always emit OSC 8 hyperlinks), `"none"` (disable)
- Defaults to `"auto"` for backwards compatibility
- Passes the setting through to both CLI and TUI rendering paths

## Motivation

`auto` detection relies on `TERM_PROGRAM` which doesn't work inside tmux (reports `tmux` instead of the outer terminal). A config option lets users force inline hyperlinks when they know their terminal supports it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/charmbracelet/codesmith/glow/pr/1016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789310417&installation_model_id=432448&pr_number=1016&repository=charmbracelet%2Fglow&return_to=https%3A%2F%2Fgithub.com%2Fcharmbracelet%2Fglow%2Fpull%2F1016&signature=1ca01f2a64ca68f832861b8f516959668316380d26d7acfd1571c0b271397924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->