### PR TITLE
fix: preserve blob in GitLab repository paths

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -42,7 +42,7 @@ func findGitLabREADME(u *url.URL) (*source, error) {
 		return nil, fmt.Errorf("unable to parse json: %w", err)
 	}
 
-	readmeRawURL := strings.ReplaceAll(result.ReadmeURL, "blob", "raw")
+	readmeRawURL := gitLabRawURL(result.ReadmeURL)
 
 	if res.StatusCode == http.StatusOK {
 		//nolint:bodyclose
@@ -58,4 +58,8 @@ func findGitLabREADME(u *url.URL) (*source, error) {
 	}
 
 	return nil, errors.New("can't find README in GitLab repository")
+}
+
+func gitLabRawURL(readmeURL string) string {
+	return strings.Replace(readmeURL, "/-/blob/", "/-/raw/", 1)
 }

--- a/gitlab_test.go
+++ b/gitlab_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestGitLabRawURLPreservesBlobInProjectName(t *testing.T) {
+	const readmeURL = "https://gitlab.com/Sjoerdlab/openblob/-/blob/main/README.md"
+	const want = "https://gitlab.com/Sjoerdlab/openblob/-/raw/main/README.md"
+
+	if got := gitLabRawURL(readmeURL); got != want {
+		t.Fatalf("expected raw README URL %q, got %q", want, got)
+	}
+}


### PR DESCRIPTION
Glow converts GitLab README page URLs into raw file URLs before downloading them. The current replacement changes every occurrence of `blob`, not only GitLab's route segment. For example, `Sjoerdlab/openblob/-/blob/main/README.md` becomes `Sjoerdlab/openraw/-/raw/main/README.md`, so Glow requests the wrong project.

This changes only `/-/blob/` to `/-/raw/`, leaving group, project, branch, and file names untouched. It also adds a regression test for a project name containing `blob`.

Tested with `go test ./...`.
