### PR TITLE
fix: respect detected background for "auto" style on markdown

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 
 	"charm.land/glamour/v2"
 	"charm.land/glamour/v2/ansi"
@@ -69,14 +70,22 @@ func IsMarkdownFile(filename string) bool {
 	return false
 }
 
+// autoStyle resolves the "auto" style to a concrete standard style by querying
+// the terminal for its background color. The query is made at most once per
+// process: GlamourStyle is called once per rendered document, and repeatedly
+// querying the terminal would interfere with the TUI's input handling.
+var autoStyle = sync.OnceValue(func() string {
+	if lipgloss.HasDarkBackground(os.Stdin, os.Stdout) {
+		return styles.DarkStyle
+	}
+	return styles.LightStyle
+})
+
 // GlamourStyle returns a glamour.TermRendererOption based on the given style.
 func GlamourStyle(style string, isCode bool) glamour.TermRendererOption {
 	if !isCode {
 		if style == "auto" {
-			if lipgloss.HasDarkBackground(os.Stdin, os.Stdout) {
-				return glamour.WithStandardStyle(styles.DarkStyle)
-			}
-			return glamour.WithStandardStyle(styles.LightStyle)
+			return glamour.WithStandardStyle(autoStyle())
 		}
 		return glamour.WithStylePath(style)
 	}
@@ -88,7 +97,7 @@ func GlamourStyle(style string, isCode bool) glamour.TermRendererOption {
 
 	switch style {
 	case "auto":
-		if lipgloss.HasDarkBackground(os.Stdin, os.Stdout) {
+		if autoStyle() == styles.DarkStyle {
 			styleConfig = styles.DarkStyleConfig
 		} else {
 			styleConfig = styles.LightStyleConfig

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -73,7 +73,10 @@ func IsMarkdownFile(filename string) bool {
 func GlamourStyle(style string, isCode bool) glamour.TermRendererOption {
 	if !isCode {
 		if style == "auto" {
-			return glamour.WithStandardStyle("dark")
+			if lipgloss.HasDarkBackground(os.Stdin, os.Stdout) {
+				return glamour.WithStandardStyle(styles.DarkStyle)
+			}
+			return glamour.WithStandardStyle(styles.LightStyle)
 		}
 		return glamour.WithStylePath(style)
 	}


### PR DESCRIPTION
Fixes #1022. Also the regression reported in #1020 and in the comments on #1007. Refs #877.

(#1007 itself is a feature request for separate light/dark theme paths and stays open; this only restores detection.)

## Problem

`auto` resolves to `dark` for every markdown file, whatever the terminal reports. On a light terminal that means light-grey text on a light background.

`GlamourStyle` hardcodes it on the `!isCode` path:

```go
	if !isCode {
		if style == "auto" {
			return glamour.WithStandardStyle("dark")
		}
```

while the detection sits ten lines below, reachable only for code files:

```go
	case "auto":
		if lipgloss.HasDarkBackground(os.Stdin, os.Stdout) {
```

Markdown files are `!isCode`, so the terminal's reply is never consulted. This came in with the glamour v2 migration — glamour dropped auto-style in charmbracelet/glamour#410 and handed the query to Lip Gloss, and only the code path was updated.

## Change

Two commits, one file, +14/−2:

1. **Resolve `auto` through `HasDarkBackground` on the markdown path.** The fix for the bug itself.
2. **Cache the result with `sync.OnceValue` and share it with the code path.** `GlamourStyle` runs once per rendered document (`ui/pager.go:368`), so an uncached call would query the terminal on every render inside a running Bubble Tea program and fight its input reader. Once per process, at first render.

The second commit also removes the pre-existing per-render query on the code block path. Happy to drop it if you'd rather keep this to the one-line fix.

## Verification

Under a pty that acts as a terminal and answers OSC 11, so the result does not depend on the terminal used:

| | body colour | |
|---|---|---|
| before, auto + terminal reports **light** | `38;5;252` | dark theme ✗ |
| before, auto + terminal silent | `38;5;252` | dark theme |
| **after**, auto + terminal reports **light** | `38;5;234` | light theme ✓ |
| **after**, auto + terminal silent | `38;5;252` | dark fallback ✓ |
| reference `-s light` | `38;5;234` | |
| reference `-s dark` | `38;5;252` | |

After the change, `auto` on a light terminal is byte-identical to `-s light` apart from the detection query itself. Explicit `-s light` / `-s dark` are unchanged. The probe fires once regardless of document count.

`go build ./...` and `go vet ./...` clean; `gofmt -l` reports only the pre-existing `console_windows.go`.

## Out of scope

TUI mode already gets the background over `tea.RequestBackgroundColor` (`ui/ui.go:162`) but does not feed it to `GlamourStyle`, so the TUI takes the same one-shot probe as the CLI. Wiring the Bubble Tea message through belongs with #953.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/charmbracelet/codesmith/glow/pr/1023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790429705&installation_model_id=432448&pr_number=1023&repository=charmbracelet%2Fglow&return_to=https%3A%2F%2Fgithub.com%2Fcharmbracelet%2Fglow%2Fpull%2F1023&signature=5e67f60dac22ad8d7be758c4156c17758b097112600483df68c95ecffc437667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->