### PR TITLE
fix(ui): scroll left with h/left instead of leaving the document

### DIFF
--- a/ui/pager.go
+++ b/ui/pager.go
@@ -298,27 +298,48 @@ func (m pagerModel) statusBarView(b *strings.Builder) {
 }
 
 func (m pagerModel) helpView() (s string) {
+	// Column widths, in cells.
+	const col0Width = 29
+
+	col0 := []string{
+		"k/↑      up",
+		"j/↓      down",
+		"b/pgup   page up",
+		"f/pgdn   page down",
+		"u        ½ page up",
+		"d        ½ page down",
+		"l/→      scroll right",
+		"h/←      scroll left",
+	}
 	col1 := []string{
 		"g/home  go to top",
 		"G/end   go to bottom",
 		"c       copy contents",
 		"e       edit this document",
 		"r       reload this document",
-		"esc     back to files",
-		"q       quit",
+	}
+	if !m.common.documentOnly {
+		col1 = append(col1, "esc/h   back to files")
+	}
+	col1 = append(col1, "q       quit")
+
+	rows := max(len(col0), len(col1))
+	rowLines := make([]string, 0, rows)
+	for i := 0; i < rows; i++ {
+		var left, right string
+		if i < len(col0) {
+			left = col0[i]
+		}
+		if i < len(col1) {
+			right = col1[i]
+		}
+		if right != "" {
+			left += strings.Repeat(" ", max(col0Width-runewidth.StringWidth(left), 0))
+		}
+		rowLines = append(rowLines, left+right)
 	}
 
-	s += "\n"
-	s += "k/↑      up                  " + col1[0] + "\n"
-	s += "j/↓      down                " + col1[1] + "\n"
-	s += "b/pgup   page up             " + col1[2] + "\n"
-	s += "f/pgdn   page down           " + col1[3] + "\n"
-	s += "u        ½ page up           " + col1[4] + "\n"
-	s += "d        ½ page down         "
-
-	if len(col1) > 5 {
-		s += col1[5]
-	}
+	s += "\n" + strings.Join(rowLines, "\n")
 
 	s = indent(s, 2)
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -83,6 +83,10 @@ type commonModel struct {
 	width  int
 	height int
 	styles Styles
+
+	// documentOnly reports whether Glow was started on a single document. In
+	// that case there is no file listing to go back to.
+	documentOnly bool
 }
 
 type model struct {
@@ -130,6 +134,7 @@ func newModel(cfg Config, content string) tea.Model {
 	path := cfg.Path
 	if path == "" && content != "" {
 		m.state = stateShowDocument
+		m.common.documentOnly = true
 		m.pager.currentDocument = markdown{Body: content}
 		return m
 	}
@@ -148,6 +153,7 @@ func newModel(cfg Config, content string) tea.Model {
 	} else {
 		cwd, _ := os.Getwd()
 		m.state = stateShowDocument
+		m.common.documentOnly = true
 		m.pager.currentDocument = markdown{
 			localPath: path,
 			Note:      stripAbsolutePath(path, cwd),
@@ -194,6 +200,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		switch msg.String() {
 		case "esc":
+			if m.common.documentOnly {
+				break
+			}
 			if m.state == stateShowDocument || m.stash.viewState == stashStateLoadingDocument {
 				batch := m.unloadDocument()
 				return m, tea.Batch(batch...)
@@ -226,6 +235,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case "left", "h", "delete":
 			if m.state == stateShowDocument {
+				// If the document is scrolled horizontally, scroll back left
+				// instead of leaving the document. The pager handles the
+				// actual scrolling, so just pass the key through.
+				if m.pager.viewport.XOffset() > 0 || m.common.documentOnly {
+					break
+				}
 				cmds = append(cmds, m.unloadDocument()...)
 				return m, tea.Batch(cmds...)
 			}

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -1,0 +1,76 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func newTestModel(t *testing.T, documentOnly bool) model {
+	t.Helper()
+
+	m := model{
+		common: &commonModel{
+			styles:       newStyles(true),
+			width:        20,
+			height:       10,
+			documentOnly: documentOnly,
+		},
+		state: stateShowDocument,
+	}
+	m.pager = newPagerModel(m.common)
+	m.stash = newStashModel(m.common)
+	m.pager.setSize(m.common.width, m.common.height)
+	m.pager.setContent(strings.Repeat("x", 200))
+	return m
+}
+
+func press(t *testing.T, m model, key rune) model {
+	t.Helper()
+
+	newModel, _ := m.Update(tea.KeyPressMsg{Code: key, Text: string(key)})
+	return newModel.(model)
+}
+
+func TestScrollLeftBeforeLeavingDocument(t *testing.T) {
+	m := newTestModel(t, false)
+
+	m = press(t, m, 'l')
+	offset := m.pager.viewport.XOffset()
+	if offset == 0 {
+		t.Fatal("l did not scroll right")
+	}
+
+	m = press(t, m, 'h')
+	if m.state != stateShowDocument {
+		t.Fatal("h left the document while it was scrolled right")
+	}
+	if m.pager.viewport.XOffset() >= offset {
+		t.Fatalf("h did not scroll left: %d -> %d", offset, m.pager.viewport.XOffset())
+	}
+
+	for i := 0; i < 20 && m.pager.viewport.XOffset() > 0; i++ {
+		m = press(t, m, 'h')
+	}
+
+	m = press(t, m, 'h')
+	if m.state != stateShowStash {
+		t.Fatalf("h at the left edge did not go back to the file listing, state = %v", m.state)
+	}
+}
+
+func TestDocumentOnlyStaysInDocument(t *testing.T) {
+	m := newTestModel(t, true)
+
+	m = press(t, m, 'h')
+	if m.state != stateShowDocument {
+		t.Fatal("h left the only document there is")
+	}
+
+	newModel, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	m = newModel.(model)
+	if m.state != stateShowDocument {
+		t.Fatal("esc left the only document there is")
+	}
+}


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features). Not a new feature, this is a bug fix for #1026.

Fixes #1026

### Before

1. `glow -t wide.md` on a file with lines wider than the terminal
2. `l` / `right` scrolls right
3. `h` / `left` leaves the document
4. Because Glow was started on one file, the file listing was never populated, so you land on an empty "0 documents / Looking for local files..." screen with no way back

Cause: `ui.go` handles `left`, `h` and `delete` and unloads the document before the pager viewport sees the key, while `l` falls through to the viewport and scrolls, since `bubbles/viewport` binds `h`/`left` and `l`/`right` to horizontal scrolling. `Init` only starts a file search in the stash state, so a single-document session has no listing to return to. `esc` has the same dead end.

### After

1. `h` / `left` scrolls left while the viewport is scrolled
2. At the left edge it goes back to the file listing as before
3. In a single-document session `h` and `esc` keep the document loaded
4. The pager help lists both scroll keys and hides "back to files" when there are no files to go back to

### Notes

The help view is rebuilt from two column slices instead of fixed rows so entries can be added or hidden without breaking alignment. The old code rendered a fixed six rows and silently dropped the last entry of its right column (`q quit`).

Tests: `TestScrollLeftBeforeLeavingDocument` and `TestDocumentOnlyStaysInDocument` in `ui/ui_test.go`.
