### PR TITLE
fix: add nil check to inotify watch

### DIFF
--- a/ui/pager.go
+++ b/ui/pager.go
@@ -411,15 +411,28 @@ func glamourRender(m pagerModel, markdown string) (string, error) {
 	return content.String(), nil
 }
 
+// newWatcher creates the file watcher. It's a variable so tests can simulate
+// the watcher failing to initialize.
+var newWatcher = fsnotify.NewWatcher
+
 func (m *pagerModel) initWatcher() {
-	var err error
-	m.watcher, err = fsnotify.NewWatcher()
+	watcher, err := newWatcher()
 	if err != nil {
-		log.Error("error creating fsnotify watcher", "error", err)
+		// This happens when the system runs out of inotify instances (or the
+		// platform equivalent). It isn't fatal: we just lose live reloading,
+		// so leave the watcher nil and carry on.
+		log.Error("error creating fsnotify watcher, live reload is disabled", "error", err)
+		m.watcher = nil
+		return
 	}
+	m.watcher = watcher
 }
 
 func (m *pagerModel) watchFile() tea.Msg {
+	if m.watcher == nil {
+		return nil
+	}
+
 	dir := m.localDir()
 
 	if err := m.watcher.Add(dir); err != nil {
@@ -452,6 +465,10 @@ func (m *pagerModel) watchFile() tea.Msg {
 }
 
 func (m *pagerModel) unwatchFile() {
+	if m.watcher == nil {
+		return
+	}
+
 	dir := m.localDir()
 
 	err := m.watcher.Remove(dir)

--- a/ui/pager_test.go
+++ b/ui/pager_test.go
@@ -1,0 +1,98 @@
+package ui
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// newTestPager returns a pager model pointing at a markdown file in a fresh
+// temporary directory, along with that file's path.
+func newTestPager(t *testing.T) (*pagerModel, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	// macOS hands out symlinked temp dirs (/var -> /private/var), while
+	// fsnotify reports the resolved path, so resolve it up front.
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = resolved
+	}
+
+	path := filepath.Join(dir, "test.md")
+	if err := os.WriteFile(path, []byte("# hello\n"), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+
+	m := newPagerModel(&commonModel{})
+	m.currentDocument = markdown{localPath: path}
+	return &m, path
+}
+
+// When fsnotify can't create a watcher — the usual cause being an exhausted
+// inotify instance limit — the pager must degrade to "no live reload" rather
+// than dereference a nil watcher.
+func TestPagerWatcherInitFailure(t *testing.T) {
+	orig := newWatcher
+	newWatcher = func() (*fsnotify.Watcher, error) {
+		return nil, errors.New("too many open files")
+	}
+	t.Cleanup(func() { newWatcher = orig })
+
+	m, _ := newTestPager(t)
+
+	if m.watcher != nil {
+		t.Fatalf("expected nil watcher after init failure, got %#v", m.watcher)
+	}
+
+	// Each of these used to panic with a nil pointer dereference.
+	if msg := m.watchFile(); msg != nil {
+		t.Errorf("expected nil msg from watchFile with no watcher, got %#v", msg)
+	}
+	m.unwatchFile()
+	m.unload()
+}
+
+// The watcher is still nil-safe if init failed and the document changes, which
+// is the path the pager takes on every render.
+func TestPagerWatchFileNilWatcherRepeatedly(t *testing.T) {
+	m, _ := newTestPager(t)
+	m.watcher = nil
+
+	for range 3 {
+		if msg := m.watchFile(); msg != nil {
+			t.Fatalf("expected nil msg from watchFile with no watcher, got %#v", msg)
+		}
+		m.unwatchFile()
+	}
+}
+
+// A working watcher must still report writes to the current document.
+func TestPagerWatchFileReload(t *testing.T) {
+	m, path := newTestPager(t)
+	if m.watcher == nil {
+		t.Skip("could not create fsnotify watcher on this system")
+	}
+	t.Cleanup(func() { _ = m.watcher.Close() })
+
+	msgs := make(chan any, 1)
+	go func() { msgs <- m.watchFile() }()
+
+	// Give watchFile a moment to register the directory before touching it.
+	time.Sleep(100 * time.Millisecond)
+	if err := os.WriteFile(path, []byte("# hello again\n"), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+
+	select {
+	case msg := <-msgs:
+		if _, ok := msg.(reloadMsg); !ok {
+			t.Fatalf("expected reloadMsg, got %#v", msg)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for reloadMsg")
+	}
+}


### PR DESCRIPTION
- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] ~I have created a discussion that was approved by a maintainer (for new features).~

This PR resolves an issue where Glow panics on startup when the system can't hand out any more inotify instances. `fsnotify.NewWatcher()` fails, `initWatcher` only logs it, and `watchFile` then calls `Add` on a nil watcher.

## Changes

This PR makes only a few small changes:

1. In `initWatcher()`, call `fsnotify.NewWatcher` via a variable so that tests can simulate a failed initialization
2. If we got an error, explicitly set `pagerModel.watcher` to `nil`
3. In `watchFile()` and `unwatchFile()`, add a nil check for the watcher instance and return.

We also add some unit tests for the pager while we're here.

## Reproduction

On a clean Linux box:

```sh
# 1. Determine the current number of max_user_instances (to restore later)
sysctl fs.inotify.max_user_instances

# 2. Exhaust the per-user inotify instance limit
sudo sysctl -w fs.inotify.max_user_instances=0

# 3. Open any document in the TUI
glow -t README.md
```

Before this change:

```
Caught panic:
runtime error: invalid memory address or nil pointer dereference
    glow/ui.(*pagerModel).watchFile (ui/pager.go:425)
```

After this change the document renders normally; live reload is off and the log records `error creating fsnotify watcher, live reload is disabled`. Press `r` to reload manually.

```sh
# Restore the limit
sudo sysctl -w fs.inotify.max_user_instances=256 # (or the number returned from the first step above)
```

## AI Disclosure

This issue was diagnosed, and the code written, with the help of "Claude Opus 5 (1M context) with high effort"; all code has been reviewed by me personally to ensure I understand the issue at hand, the fix implemented, the code as written, and the effect it will have on the program as a whole.